### PR TITLE
Add predicates

### DIFF
--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -75,20 +75,21 @@ def sameSevenCharStartPredicate(field):
 def commonSetPredicate(field_set):
     if len(field_set) == 0:
         return ()
-    return(str(field))
+    return(str(field_set))
 
 def commonSetElementPredicate(field_set):
     """return set as individual elements"""
     if len(field_set) < 1:
         return ()
 
-    return tuple(str(f) for f in field)
+    return tuple(str(f) for f in field_set)
 
 def roundToBase(x, base):
     """Given a float and a base, return the spanning values to the nearest base"""
-    base_ceil = float(base * math.ceil(float(x) / base))
-    base_floor = float(base * math.floor(float(x) / base))
-    return base_floor, base_ceil
+    base_log = int(-1 * math.log10(base))
+    base_ceil = round(float(base * math.ceil(float(x) / base)), base_log)
+    base_floor = round(float(base * math.floor(float(x) / base)), base_log)
+    return [base_floor, base_ceil]
 
 def checkEqual(iter):
     if len(set(iter)) > 1:
@@ -126,5 +127,5 @@ def latLongGridPredicate(field, base=0.1):
     if checkEqual(long_grid):
         long_grid = expandGrid(long_grid, base)
     
-    grid = (lat_grid, long_grid)
+    grid = (tuple(lat_grid), tuple(long_grid))
     return str(grid)

--- a/test/test_predicates.py
+++ b/test/test_predicates.py
@@ -3,32 +3,32 @@ from dedupe import predicates
 
 class TestCommonSet(unittest.TestCase):
     def setUp(self):
-        self.s1 = set('red', 'blue', 'green')
+        self.s1 = set(['red', 'blue', 'green'])
 
     def test_full_set(self):
-        block_val = predicate.commonSetPredicate(self.s1)
-        self.assertEqual(block_val, str(s1))
+        block_val = predicates.commonSetPredicate(self.s1)
+        self.assertEqual(block_val, str(self.s1))
 
     def test_empty_set(self):
-        block_val = predicate.commonSetPredicate(set())
+        block_val = predicates.commonSetPredicate(set())
         self.assertEqual(block_val, tuple())
 
 class TestSetElement(unittest.TestCase):
     def setUp(self):
-        self.s1 = set('red', 'blue', 'green')
+        self.s1 = set(['red', 'blue', 'green'])
 
     def test_long_set(self):
-        block_val = predicate.commonSetElementPredicate(self.s1)
-        self.assertEqual(block_val, ('red', 'blue', 'green'))
+        block_val = predicates.commonSetElementPredicate(self.s1)
+        self.assertEqual(block_val, ('blue', 'green', 'red'))
 
     def test_empty_set(self):
-        block_val = predicate.commonSetElementPredicate(set())
+        block_val = predicates.commonSetElementPredicate(set())
         self.assertEqual(block_val, tuple())
 
 class TestLatLongGrid(unittest.TestCase):
     def setUp(self):
         self.latlong1 = (42.335, -5.212)
-        self.latlong1grid = str( ((43.3, 43.4),(-5.2, -5.3)))
+        self.latlong1grid = str( ((42.3, 42.4),(-5.3, -5.2)))
         self.latlong2 = (42, -5)
         self.latlong2grid = str(((41.9, 42.1), (-5.1, -4.9)))
 


### PR DESCRIPTION
Provides blocking predicates for:
1. Set: all elements of set equal
2. Set: any element of set equal
3. Lat/Long: bounding box in degrees lat/long

Unit tests for each are included.
