### PR TITLE
Update predicates.py

### DIFF
--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -57,7 +57,7 @@ def initials(field, n=None):
     >>> initials("noslice")
     ('noslice', )
     """
-    return (field[:n], ) if not n or len(field) > n-1 else () 
+    return (field[:n], ) if n is not None or len(field) > n-1 else () 
 
 def wholeFieldPredicate(field):
     """return the whole field


### PR DESCRIPTION
1. Spelling on docstring for sameSevenCharStartPredicate, "characters"
2. same"N"CharStartPredicate results in substantial redundancy. Consider deprecating in favor of: initials
   3. common"N"Gram -> ngrams

Questions: How should spaces be regarded within a 'field' for the ngrams function?

Issues:
- nearIntegersPredicate(field) disregards negative integers indicated by "-" (other than -1 in the case of 0)

Consider also:

def ingrams(field, n):
    """produces an iterator over ngrams generated from a sequence of items
    
    see: http://nltk.googlecode.com/svn/trunk/doc/api/nltk.util-module.html#ingrams
    """
    ...
