### PR TITLE
Don't encourage users to run a hanging command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wiki](http://dedupe.readthedocs.org/en/latest/OSX-Install-Notes.html).
 
 Unit tests of core dedupe functions
 ```bash
-nosetests
+coverage run -m nose -I canonical_test
 ```
 
 #### Test using canonical dataset from Bilenko's research


### PR DESCRIPTION
`nosetests` hangs on some machines, while `coverage run -m nose -I
canonical_test` doesn't seem to. For onboarding new developers, let's
not tell them to use commands that might not work.
