### PR TITLE
fix field spec format for canonical_test_matching

### DIFF
--- a/tests/canonical_test_matching.py
+++ b/tests/canonical_test_matching.py
@@ -72,11 +72,11 @@ if os.path.exists(settings_file):
     with open(settings_file) as f :
         deduper = dedupe.StaticRecordLink(f)
 else:
-    fields = {'name': {'type': 'String'},
-              'address': {'type': 'String'},
-              'cuisine': {'type': 'String'},
-              'city' : {'type' : 'String'}
-              }
+    fields = [{'field': 'name', 'type': 'String'},
+              {'field': 'address', 'type': 'String'},
+              {'field': 'cuisine', 'type': 'String'},
+              {'field': 'city','type' : 'String'}
+              ]
 
     deduper = dedupe.RecordLink(fields)
     deduper.sample(data_1, data_2, 100000) 


### PR DESCRIPTION
canonical_test_matching.py was dying with an exception that complained about the format of the DataModel. I made what appears to be the appropriate fix.
