### PR TITLE
Components -> Cliques in Dedupe class

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -242,12 +242,11 @@ class DedupeMatching(Matching):
         error = 0
         n = 0
         for component in components:
-            if False or len(component) > 1:
+            if len(component) > 1:
                 record_ids = numpy.unique(component['pairs'])
                 N = len(record_ids)
-                all_edges = N * (N - 1) / 2
+                all_edges = int(N * (N - 1) / 2)
                 if all_edges > len(component):
-                    print(component)
                     edges = set(map(tuple, component['pairs']))
                     row = len(component)
                     clique = numpy.resize(component, all_edges)
@@ -265,7 +264,6 @@ class DedupeMatching(Matching):
                              row += 1
 
                     component = clique
-                    print(component)
                     
             yield component
 

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -97,7 +97,7 @@ def condensedDistance(dupes):
     '''
 
     candidate_set = numpy.unique(dupes['pairs'])
-    candidate_set = numpy.sort(candidate_set)
+    candidate_set.sort()
 
     i_to_id = dict(enumerate(candidate_set))
 
@@ -117,9 +117,9 @@ def condensedDistance(dupes):
     return i_to_id, condensed_distances, N
 
 
-def cluster(dupes, threshold=.5, max_components=30000):
+def cluster(dupe_components, threshold=.5):
     '''
-    Takes in a list of duplicate pairs and clusters them in to a
+    Takes in an iterator of connected components and cluster into a
     list records that all refer to the same entity based on a given
     threshold
 
@@ -130,9 +130,7 @@ def cluster(dupes, threshold=.5, max_components=30000):
     '''
     threshold = 1 - threshold
 
-    dupe_sub_graphs = connected_components(dupes, max_components)
-
-    for sub_graph in dupe_sub_graphs:
+    for sub_graph in dupe_components:
         if len(sub_graph) > 1:
 
             i_to_id, condensed_distances, N = condensedDistance(sub_graph)


### PR DESCRIPTION
If we don't learn blocking rules that lead to the comparison of every true dupes, we can get comparisons that look like this

record 10 - record 11 : 90% match
record 11 - record 12:  95% match

but no comparison for record 10 - record 11

Right now, in the clustering stage, we act as we did compare record 10 - record 12, and that the classifier said there was a 0% chance of matching. This often leads the cluster to put these three records into two clusters instead of one.

This is certainly not the optimal strategy.

Alternatives are to
1. Assume transitivity and calculate the transitive score for non-compared records within a connected component. So, we would assume that record 10 - record 12 would have a comparison score of .90 * .95 = 0.8550. This would be pretty easy.
2. After doing all the blocking and comparing all the records, find the connected components. Identify all the missing comparisons within a component and the compare those. This probably the most correct thing to do, but would require a significant changes to the code.

---

This PR has a hack to identify all the missing comparisons in a connected component and compare those. Right now the API for this is unacceptable, but this can either evolved into better code that uses this approach or it can provide the baseline against which we can compare the transitivity approach.