### PR TITLE
Don't call _cluster on empty list

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -118,7 +118,7 @@ class Matching(object):
 
         logger.debug("matching done, begin clustering")
 
-        clusters = list(self._cluster(matches, threshold, *args, **kwargs)) if matches else []
+        clusters = list(self._cluster(matches, threshold, *args, **kwargs)) if matches != [] else []
 
         try:
             match_file = matches.filename

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -118,7 +118,7 @@ class Matching(object):
 
         logger.debug("matching done, begin clustering")
 
-        clusters = list(self._cluster(matches, threshold, *args, **kwargs))
+        clusters = list(self._cluster(matches, threshold, *args, **kwargs)) if matches else []
 
         try:
             match_file = matches.filename


### PR DESCRIPTION
`scoreDuplicates` sometimes returns a `numpy.mmep` and other times returns an empty list. This
results in a type error in `connectedCommponents` which expects `edgelist` to be
dict-like. (Perhaps `scoreDuplicates` should return None rather than an empty list?)