### PR TITLE
Change all documentation links to the new canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install "numpy>=1.9"
 pip install dedupe
 ```
 
-Familiarize yourself with [dedupe's API](https://dedupe.readthedocs.io/en/latest/API-documentation.html), and get started on your project. Need inspiration? Have a look at [some examples](https://github.com/dedupeio/dedupe-examples).
+Familiarize yourself with [dedupe's API](https://dedupe.io/developers/library/en/latest/API-documentation.html), and get started on your project. Need inspiration? Have a look at [some examples](https://github.com/dedupeio/dedupe-examples).
 
 ### Developing dedupe
 

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -602,7 +602,7 @@ class ActiveMatching(Matching):
         describes a variable to use for comparing records.
 
         For details about variable types, check the documentation.
-        <https://dedupe.readthedocs.io>`_
+        <https://dedupe.io/developers/library>`_
         """
         self.data_model = datamodel.DataModel(variable_definition)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ dedupe takes in human training data and comes up with the best rules for your da
 Important links
 ===============
 
-* Documentation: https://dedupe.readthedocs.io/
+* Documentation: https://dedupe.io/developers/library
 * Repository: https://github.com/datamade/dedupe
 * Issues: https://github.com/datamade/dedupe/issues
 * Mailing list: https://groups.google.com/forum/#!forum/open-source-deduplication  

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
 
     Important links:
 
-    * Documentation: https://dedupe.readthedocs.io/
+    * Documentation: https://dedupe.io/developers/library
     * Repository: https://github.com/dedupeio/dedupe
     * Issues: https://github.com/dedupeio/dedupe/issues
     * Mailing list: https://groups.google.com/forum/#!forum/open-source-deduplication


### PR DESCRIPTION
This PR finds all references to the old docs at `dedupe.readthedocs.io` and updates them to the new canonical documentation `dedupe.io/developers/library`.