### PR TITLE
Style documentation version box

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -167,6 +167,21 @@ h4:before, h4:before, h6:before {
     text-align: right;
 }
 
+/* Version box in the lower left-hand corner */
+.rst-versions {
+    background: #ababab;
+    border-top: none;
+}
+
+.rst-versions .rst-current-version {
+    background-color: #7d7d7d;
+    color: #ffffff;
+}
+
+.rst-versions .rst-other-versions {
+    color: #4e4e4e;
+}
+
 /* ============= */
 /* Media queries */
 /* ============= */

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -28,6 +28,38 @@ a, a:visited, .wy-menu-vertical a { color: #c11133;}
 a:hover { color: #730a1e;}
 a:active, a:focus { outline: 0;}
 
+.navbar-nav > li > a,
+.navbar-brand {
+    height: 40px;
+}
+
+.navbar {
+    min-height: 40px;
+}
+
+.navbar-fixed-top .navbar-collapse {
+    padding-right: 15px;
+}
+
+.navbar-default .navbar-nav > li > a {
+    padding-top: 11px;
+    height: 40px;
+}
+
+.nav > li {
+    font-size: 0.9em;
+}
+
+.navbar-default .navbar-nav > li > a:hover {
+    color: #d9230f;
+    background-color: transparent;
+}
+
+.navbar-brand {
+    font-size: 17px;
+    padding: 11px 15px;
+}
+
 /* ================ */
 /* Navs and footers */
 /* ================ */

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -34,6 +34,7 @@
         <li><a href="https://dedupe.io/#demo"><i class='fa fa-fw fa-play-circle'></i> Demo</a></li>
         <li><a href="https://dedupe.io/#sign-up"><i class='fa fa-fw fa-check-square-o'></i> Sign up</a></li>
         <li><a href="https://dedupe.io/tutorials/"><i class='fa fa-fw fa-info-circle'></i> Tutorials</a></li>
+        <li><a href="https://dedupe.io/developers/"><i class='fa fa-fw fa-code'></i> Developers</a></li>
         <li><a href="https://app.dedupe.io/login?next=%2F"><i class='fa fa-fw fa-sign-in'></i> Login</a></li>
       </ul>
     </div><!--/.nav-collapse -->


### PR DESCRIPTION
Styles the documentation version box to look like this:

### Box closed
<img width="1278" alt="screen shot 2017-05-15 at 1 39 54 pm" src="https://cloud.githubusercontent.com/assets/14170650/26073281/042d2612-3974-11e7-97f3-4daf56694556.png">

### Box open
<img width="1277" alt="screen shot 2017-05-15 at 1 40 01 pm" src="https://cloud.githubusercontent.com/assets/14170650/26073283/078e961a-3974-11e7-9a66-628a3c6a89dc.png">
