### PR TITLE
Remove print statement that gets passed into stdout

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -866,7 +866,6 @@ class RecordLink(RecordLinkMatching, ActiveMatching):
         if original_length_2 is None:
             original_length_2 = len(data_2)
         self.sampled_records_2 = Sample(data_2, 600, original_length_2)
-        print('foo')
 
         self.active_learner = self.ActiveLearner(self.data_model)
         self.active_learner.sample_product(data_1, data_2,


### PR DESCRIPTION
There's a print statement in the `RecordLink.sample` method of `api.py` that has been getting pushed to stdout and printed in all of my output files. This PR removes it.