### PR TITLE
try to always use multiprocessing queues

### DIFF
--- a/dedupe/backport.py
+++ b/dedupe/backport.py
@@ -26,16 +26,15 @@ elif platform.system() == 'Windows' :
     warnings.warn("Dedupe does not currently support multiprocessing on Windows")
     MULTIPROCESSING = False
 
+from multiprocessing import Queue
+if sys.version < '3':
+    from multiprocessing.queues import SimpleQueue
+else :
+    from multiprocessing import SimpleQueue
+
 if MULTIPROCESSING :        
-    from multiprocessing import Process, Pool, Queue
-    if sys.version < '3':
-        from multiprocessing.queues import SimpleQueue
-    else :
-        from multiprocessing import SimpleQueue
+    from multiprocessing import Process, Pool
 else :
     if not hasattr(threading.current_thread(), "_children"): 
         threading.current_thread()._children = weakref.WeakKeyDictionary()
-    from multiprocessing.dummy import Process, Pool, Queue
-    SimpleQueue = Queue
-
-
+    from multiprocessing.dummy import Process, Pool

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -180,10 +180,11 @@ def mergeScores(score_queue, result_queue, stop_signals) :
 
 def scoreDuplicates(records, data_model, classifier, num_cores=1, threshold=0) :
     if num_cores < 2 :
-        from multiprocessing.dummy import Process, Queue
-        SimpleQueue = Queue
+        from multiprocessing.dummy import Process
     else :
-        from .backport import Process, SimpleQueue, Queue
+        from .backport import Process
+
+    from .backport import SimpleQueue, Queue
 
     first, records = peek(records)
     if first is None:


### PR DESCRIPTION
right now, when we don't do multiprocessing we use the threading queue https://docs.python.org/3.4/library/queue.html#module-queue

Under the hood this is just a deque, which is probably holding on memory . Using the multiprocessing queues will both reduce complexity and hopefully help address memory issues on non-multiprocessing machines.