### PR TITLE
fix for nearIntegersPredicate

### DIFF
--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -272,9 +272,9 @@ def nearIntegersPredicate(field):
     ints = integers(field)
     near_ints = set()
     for char in ints :
-        near_ints.add(char)
         num = int(char)
         near_ints.add(str(num-1))
+        near_ints.add(str(num))
         near_ints.add(str(num+1))
         
     return near_ints


### PR DESCRIPTION
Fixes unexpected behavior with  zero-padded integers.

Previously:
```
>>> dedupe.predicates.nearIntegersPredicate('abc 0091 cfd')
{'0091', '90', '92'}
```

With fix:
```
>>> dedupe.predicates.nearIntegersPredicate('abc 0091 cfd')
{'92', '90', '91'}
```