### PR TITLE
Make sure all links are clickable in documentation

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -87,6 +87,7 @@ h4:before, h4:before, h6:before {
     margin-top: -55px; 
     height: 55px; 
     opacity: 0;
+    pointer-events: none;
 }
 
 /* Padding for method/class permalinks, which require more finesse */


### PR DESCRIPTION
This PR closes #616 by making sure that links in the last line before headers are clickable.

To get around the sticky navbar while still using RTD's base theme, we attach an invisible `:before` pseudo-element with height and a display value of `block` to all headers. This ensures that header links take the user to the header that they expect, without having to introduce cumbersome space to the page. In this PR, I've added the CSS declaration `pointer-events: none` to the header `:before` rules to ensure that any content appearing within a `:before` pseudo-element (like a link) retains its interaction.