### PR TITLE
Rewrite Dedupe _blockData to use normal dicts and modest memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ matrix:
   - python: 2.7
   - os: osx
     language: generic
+    before_install:
+      - brew update
+      - brew install python
+      - virtualenv env -p python
+      - source env/bin/activate
   - os: osx
     language: generic
     before_install:

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -273,7 +273,7 @@ class DedupeMatching(Matching):
                                          lambda x: x[1])
         
         for record_id, block in block_groups:
-            block_keys = [block_key for block_key, _ in block]
+            block_keys = {block_key for block_key, _ in block}
             coverage[record_id] = block_keys
             for block_key in block_keys:
                 if block_key in blocks:
@@ -290,8 +290,8 @@ class DedupeMatching(Matching):
         for block_key, block in blocks.items():
             processed_block = []
             for record_id in block:
-                smaller_blocks = {key for key in coverage[record_id]
-                                  if key in blocks and key < block_key}
+                smaller_blocks = {key for key in coverage[record_id] & viewkeys(blocks)
+                                  if key < block_key}
                 processed_block.append((record_id, data_d[record_id], smaller_blocks))
 
             yield processed_block

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -273,7 +273,7 @@ class DedupeMatching(Matching):
                                          lambda x: x[1])
         
         for record_id, block in block_groups:
-            block_keys = {block_key for block_key, _ in block}
+            block_keys = [block_key for block_key, _ in block]
             coverage[record_id] = block_keys
             for block_key in block_keys:
                 if block_key in blocks:
@@ -287,12 +287,13 @@ class DedupeMatching(Matching):
         blocks = {block_key: record_ids for block_key, record_ids
                   in blocks.items() if len(record_ids) > 1}
 
+        coverage = {record_id: [k for k in cover if k in blocks]
+                    for record_id, cover in coverage.items()}
+
         for block_key, block in blocks.items():
             processed_block = []
             for record_id in block:
-                smaller_blocks = {k for k
-                                  in coverage[record_id] & viewkeys(blocks)
-                                  if k < block_key}
+                smaller_blocks = {k for k in coverage[record_id] if k < block_key}
                 processed_block.append((record_id, data_d[record_id], smaller_blocks))
 
             yield processed_block

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -268,7 +268,7 @@ class DedupeMatching(Matching):
 
         if not self.loaded_indices:
             self.blocker.indexAll(data_d)
-        
+
         block_groups = itertools.groupby(self.blocker(viewitems(data_d)),
                                          lambda x: x[1])
         

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -290,8 +290,9 @@ class DedupeMatching(Matching):
         for block_key, block in blocks.items():
             processed_block = []
             for record_id in block:
-                smaller_blocks = {key for key in coverage[record_id] & viewkeys(blocks)
-                                  if key < block_key}
+                smaller_blocks = {k for k
+                                  in coverage[record_id] & viewkeys(blocks)
+                                  if k < block_key}
                 processed_block.append((record_id, data_d[record_id], smaller_blocks))
 
             yield processed_block

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -437,20 +437,17 @@ class RecordLinkMatching(Matching):
 
     def _blockData(self, data_1, data_2):
 
-        blocked_records = core.TempShelve('blocked_records')
+        blocked_records = {}
 
         if not self.loaded_indices:
             self.blocker.indexAll(data_2)
 
         for block_key, record_id in self.blocker(data_2.items(), target=True):
-            block = blocked_records.get(block_key, {})
+            block = blocked_records.setdefault(block_key, {})
             block[record_id] = data_2[record_id]
-            blocked_records[block_key] = block
 
         for each in self._blockGenerator(data_1, blocked_records):
             yield each
-
-        blocked_records.close()
 
     def _checkBlock(self, block):
         if block:

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -6,13 +6,11 @@ import sys
 if sys.version < '3':
     text_type = unicode
     binary_type = str
-    shelve_key = lambda x: x.encode()
     int_type = long
 else:
     text_type = str
     binary_type = bytes
     unicode = str
-    shelve_key = lambda x: x
     int_type = int
 
 import itertools
@@ -23,16 +21,8 @@ import operator
 import random
 import collections
 import warnings
-import shutil
-import shelve
-import pickle
 import functools
 
-
-try:
-    import collections.abc as collections_abc
-except ImportError:
-    import collections as collections_abc
 
 import numpy
 
@@ -399,39 +389,6 @@ def Enumerator(start=0, initial=()):
         return collections.defaultdict(itertools.count(start).next, initial)
     except AttributeError : # py 3
         return collections.defaultdict(itertools.count(start).__next__, initial)
-
-
-class TempShelve(collections_abc.MutableMapping):
-    def __init__(self, filename):
-        self.path = tempfile.mkdtemp()
-        self.shelve = shelve.open(self.path + filename, 'n',
-                                  protocol=pickle.HIGHEST_PROTOCOL)
-
-    def close(self):
-        self.shelve.close()
-        shutil.rmtree(self.path)
-
-    def __getitem__(self, key):
-        key = shelve_key(key)
-        return self.shelve[key]
-
-    def __setitem__(self, key, value):
-        self.shelve[shelve_key(key)] = value
-
-    def __delitem__(self, key):
-        del self.shelve[shelve_key(key)]
-
-    def __iter__(self):
-        return iter(self.shelve)
-
-    def __len__(self):
-        return len(self.shelve)
-
-    def __contains__(self, key):
-        return shelve_key(key) in self.shelve
-
-    def values(self):
-        return viewvalues(self.shelve)
 
 
 def sniff_id_type(ids):


### PR DESCRIPTION
This removes the dbm backed shelves, but only modestly increases memory usage and sometimes decreases it.

Addresses #585, https://github.com/dedupeio/csvdedupe/issues/67, https://github.com/dedupeio/csvdedupe/issues/74