### PR TITLE
Fixed int overflow bug in randomPairsMatch 

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -71,6 +71,8 @@ def randomPairsMatch(n_records_A, n_records_B, sample_size):
 
     if sample_size >= n:
         random_pairs = numpy.arange(n)
+    elif n > numpy.iinfo(int).max:
+        random_pairs = numpy.array(random.sample(range(n), sample_size))
     else:
         random_pairs = numpy.array(random.sample(range(n), sample_size),
                                    dtype=int)


### PR DESCRIPTION
Fixed int overflow bug in randomPairsMatch when using large datasets.

Added switch to numpy default (float_) when n_records_A*n_records_B > 2147483647