### PR TITLE
Change documentation links to reflect new canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ __dedupe__ will help you:
 dedupe takes in human training data and comes up with the best rules for your dataset to quickly and automatically find similar records, even with very large databases.
 
 ## Important links
-* Documentation: https://dedupe.io/developers/library
+* Documentation: https://docs.dedupe.io/
 * Repository: https://github.com/dedupeio/dedupe
 * Issues: https://github.com/dedupeio/dedupe/issues
 * Mailing list: https://groups.google.com/forum/#!forum/open-source-deduplication
@@ -37,7 +37,7 @@ pip install "numpy>=1.9"
 pip install dedupe
 ```
 
-Familiarize yourself with [dedupe's API](https://dedupe.io/developers/library/en/latest/API-documentation.html), and get started on your project. Need inspiration? Have a look at [some examples](https://github.com/dedupeio/dedupe-examples).
+Familiarize yourself with [dedupe's API](https://docs.dedupe.io/en/latest/API-documentation.html), and get started on your project. Need inspiration? Have a look at [some examples](https://github.com/dedupeio/dedupe-examples).
 
 ### Developing dedupe
 

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -611,7 +611,7 @@ class ActiveMatching(Matching):
         describes a variable to use for comparing records.
 
         For details about variable types, check the documentation.
-        <https://dedupe.io/developers/library>`_
+        <https://docs.dedupe.io/>`_
         """
         Matching.__init__(self, num_cores, **kwargs)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,7 +113,7 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 # html_theme_options = {
-    # 'canonical_url': 'https://dedupe.io/developers/library/'
+    # 'canonical_url': 'https://docs.dedupe.io/'
 # }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ dedupe takes in human training data and comes up with the best rules for your da
 Important links
 ===============
 
-* Documentation: https://dedupe.io/developers/library
+* Documentation: https://docs.dedupe.io/
 * Repository: https://github.com/dedupeio/dedupe
 * Issues: https://github.com/dedupeio/dedupe/issues
 * Mailing list: https://groups.google.com/forum/#!forum/open-source-deduplication

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
 
     Important links:
 
-    * `Documentation <https://dedupe.io/developers/library>`_
+    * `Documentation <https://docs.dedupe.io/>`_
     * `Repository <https://github.com/dedupeio/dedupe>`_
     * `Issues <https://github.com/dedupeio/dedupe/issues>`_
     * `Mailing list <https://groups.google.com/forum/#!forum/open-source-deduplication>`_


### PR DESCRIPTION
In the process of debugging #637, we've had to move our canonical documentation URL to https://docs.dedupe.io. I've changed the canonical URL in the readthedocs admin panel and set up https://dedupe.io/developers/library/ to redirect to the new domain, but the final step is to update our links to the documentation.

Closes #637 and closes #644. 