### PR TITLE
Added pool.terminate() in  core.py to fix thread leak I was experiencing.

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -347,12 +347,16 @@ def scoreGazette(records, data_model, classifier, num_cores=1, threshold=0):
 
     first, records = peek(records)
     if first is None:
+        if pool:
+            pool.terminate()
         raise ValueError("No records to match")
 
     score_records = ScoreGazette(data_model, classifier, threshold)
 
     for scored_pairs in imap(score_records, records):
         yield scored_pairs
+    if pool:
+        pool.terminate()
 
 
 def peek(records):


### PR DESCRIPTION
The thread pool was not being cleared when score gazette was finished running. So if multiple gazetteer matches are called in a process, the threads were not being killed, and continued to accumulate.

I am using python 3.6.5 on Windows 10 with WSL running Ubuntu 16.04.

The code I was using is included here: https://github.com/Rehket/gazetteer-it