### PR TITLE
updated docs to reference and link off to Dedupe.io API docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,8 @@ Dedupe |release|
 
 *dedupe is a library that uses machine learning to perform de-duplication and entity resolution quickly on structured data.*
 
+If you're looking for the documentation for the Dedupe.io API, you can find that here: https://apidocs.dedupe.io/
+
 **dedupe** will help you: 
 
 * **remove duplicate entries** from a spreadsheet of names and addresses

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Dedupe |release|
 
 *dedupe is a library that uses machine learning to perform de-duplication and entity resolution quickly on structured data.*
 
-If you're looking for the documentation for the Dedupe.io API, you can find that here: https://apidocs.dedupe.io/
+If you're looking for the documentation for the Dedupe.io Web API, you can find that here: https://apidocs.dedupe.io/
 
 **dedupe** will help you: 
 


### PR DESCRIPTION
The docs for our API and the library look similar. To reduce confusion, I've added a link off to the Dedupe.io API docs on the main docs page