### PR TITLE
multimatching working!

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -257,8 +257,10 @@ class DedupeMatching(Matching):
         self._checkBlock(block)
 
         combinations = itertools.combinations
+        product = itertools.product
 
-        pairs = (combinations(sorted(block), 2) for block in blocks)
+        pairs = (product((block_key,), combinations(sorted(block), 2))
+                 for block_key, block in blocks)
 
         return pairs
 
@@ -298,10 +300,11 @@ class DedupeMatching(Matching):
                                   if k < block_key}
                 processed_block.append((record_id, data_d[record_id], smaller_blocks))
 
-            yield processed_block
+            yield block_key, processed_block
 
     def _checkBlock(self, block):
         if block:
+            block_key, block = block
             try:
                 id, record, smaller_ids = block[0]
             except (ValueError, KeyError):

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -294,13 +294,21 @@ class DedupeMatching(Matching):
                     for record_id, cover in coverage.items()}
 
         for block_key, block in blocks.items():
+            pred_id, _, required_matches = block_key
             processed_block = []
+
             for record_id in block:
                 smaller_blocks = {k for k in coverage[record_id]
                                   if k < block_key}
-                processed_block.append((record_id, data_d[record_id], smaller_blocks))
 
-            yield block_key, processed_block
+                possible_matches = sum(k[0] == pred_id for k in smaller_blocks)
+                if (possible_matches + 1) >= required_matches:
+                    processed_block.append((record_id,
+                                            data_d[record_id],
+                                            smaller_blocks))
+
+            if len(processed_block) > 1:
+                yield block_key, processed_block
 
     def _checkBlock(self, block):
         if block:

--- a/dedupe/blocking.py
+++ b/dedupe/blocking.py
@@ -15,7 +15,7 @@ class Blocker:
 
     def __init__(self, predicates):
 
-        self.predicates = predicates
+        self.predicates = sorted(predicates, key=lambda x: x.required_matches)
 
         self.index_fields = defaultdict(lambda: defaultdict(list))
 

--- a/dedupe/blocking.py
+++ b/dedupe/blocking.py
@@ -28,17 +28,14 @@ class Blocker:
     def __call__(self, records, target=False):
 
         start_time = time.clock()
-        predicates = [(':' + str(i), predicate)
-                      for i, predicate
-                      in enumerate(self.predicates)]
 
         for i, record in enumerate(records):
             record_id, instance = record
 
-            for pred_id, predicate in predicates:
+            for pred_id, predicate in enumerate(self.predicates):
                 block_keys = predicate(instance, target=target)
                 for block_key in block_keys:
-                    yield block_key + pred_id, record_id
+                    yield (pred_id, block_key, predicate.required_matches), record_id
 
             if i and i % 10000 == 0:
                 logger.info('%(iteration)d, %(elapsed)f2 seconds',

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -205,10 +205,13 @@ class ScoreDupes(object):
             else:
                 return False
     
-        # if the loop is able to complete, then we didn't decide that now
-        # is the time to match
         else:
-            return False
+            # if the loop exits that means that there were no
+            # smaller predicates of the current predicate type
+            if required_matches == 1:
+                return True
+            else:
+                return False
 
 class ScoreRecordLink(ScoreDupes):
     def fieldDistance(self, record_pairs):

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -182,8 +182,9 @@ class BlockLearner(object):
         dupes = [pair for label, pair in zip(y, pairs) if label]
 
         new_dupes = [pair for pair in dupes if pair not in self._old_dupes]
+        new_uncovered = (not all(self.predict(new_dupes)))
 
-        if new_dupes:
+        if new_uncovered:
             self.current_predicates = self.block_learner.learn(dupes,
                                                                recall=1.0)
             self._cached_labels = None

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -205,7 +205,8 @@ class BlockLearner(object):
             for predicate in self.current_predicates:
                 keys = predicate(record_1)
                 if keys:
-                    if set(predicate(record_2, target=True)) & set(keys):
+                    if len(set(predicate(record_2, target=True))
+                           & set(keys)) >= predicate.required_matches:
                         labels.append(1)
                         break
             else:

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -182,9 +182,8 @@ class BlockLearner(object):
         dupes = [pair for label, pair in zip(y, pairs) if label]
 
         new_dupes = [pair for pair in dupes if pair not in self._old_dupes]
-        new_uncovered = (not all(self.predict(new_dupes)))
 
-        if new_uncovered:
+        if new_dupes:
             self.current_predicates = self.block_learner.learn(dupes,
                                                                recall=1.0)
             self._cached_labels = None

--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -17,7 +17,7 @@ words = re.compile(r"[\w']+").findall
 integers = re.compile(r"\d+").findall
 start_word = re.compile(r"^([\w']+)").match
 start_integer = re.compile(r"^(\d+)").match
-alpha_numeric = re.compile(r"(?=.*\d)[a-zA-Z\d]+").findall
+alpha_numeric = re.compile(r"(?=\w*\d)[\w]+").findall
 
 if sys.version < '3':
     PUNCTUATION = string.punctuation

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -269,26 +269,26 @@ class RecordLinkBlockLearner(BlockLearner):
 
         for predicate in blocker.predicates:
             pred_cover = collections.defaultdict(lambda: (set(), set()))
-            start_block = predicate.required_matches - 1
 
             for id, record in viewitems(records_2):
                 blocks = predicate(record, target=True)
-                if start_block:
-                    blocks = sorted(blocks)[start_block:]
                 for block in blocks:
                     pred_cover[block][1].add(id)
 
             current_blocks = set(pred_cover)
             for id, record in viewitems(records_1):
                 blocks = predicate(record)
-                if start_block:
-                    blocks = sorted(blocks)[start_block:]
                 for block in set(blocks) & current_blocks:
                     pred_cover[block][0].add(id)
 
-            pairs = (pair
-                     for A, B in pred_cover.values()
-                     for pair in itertools.product(A, B))
+            pairs = collections.defaultdict(int)
+            for A, B in viewvalues(pred_cover):
+                for pair in itertools.product(A, B):
+                    pairs[pair] += 1
+
+            pairs = {k: 1 for k, v in pairs.items()
+                     if v >= predicate.required_matches}
+
             cover[predicate] = Counter(pairs)
 
         return cover

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -273,11 +273,17 @@ class RecordLinkBlockLearner(BlockLearner):
                 for block in blocks:
                     cover[predicate][block][1].add(id)
 
+            cover_count = collections.defaultdict(int)
             current_blocks = set(cover[predicate])
             for id, record in viewitems(records_1):
                 blocks = set(predicate(record))
                 for block in blocks & current_blocks:
                     cover[predicate][block][0].add(id)
+                    cover_count[block] += 1
+
+            cover[predicate] = {block : cover[predicate][block]
+                                for block, count in cover_count.items()
+                                if count >= predicate.required_matches}
 
         for predicate, blocks in cover.items():
             pairs = {pair

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -112,6 +112,8 @@ class DedupeBlockLearner(BlockLearner):
 
             for id, record in viewitems(records):
                 blocks = predicate(record)
+                if predicate.required_matches > 1:
+                    blocks = sorted(blocks)[(predicate.required_matches - 1):]
                 for block in blocks:
                     pred_cover[block].add(id)
                     covered_records[id] += 1
@@ -405,10 +407,11 @@ def coveredPairs(predicates, pairs):
     cover = {}
 
     for predicate in predicates:
+        
         coverage = {i for i, (record_1, record_2)
                     in enumerate(pairs)
-                    if (set(predicate(record_1)) &
-                        set(predicate(record_2, target=True)))}
+                    if len(set(predicate(record_1)) &
+                           set(predicate(record_2, target=True))) >= predicate.required_matches}
         if coverage:
             cover[predicate] = coverage
 

--- a/dedupe/variables/set.py
+++ b/dedupe/variables/set.py
@@ -7,16 +7,16 @@ class SetType(FieldType):
     type = "Set"
 
     _predicate_functions = (predicates.wholeSetPredicate,
-                            predicates.commonSetElementPredicate,
                             predicates.lastSetElementPredicate,
-                            predicates.commonTwoElementsPredicate,
-                            predicates.commonThreeElementsPredicate,
                             predicates.magnitudeOfCardinality,
                             predicates.firstSetElementPredicate)
 
     _index_predicates = (predicates.TfidfSetSearchPredicate,
                          predicates.TfidfSetCanopyPredicate)
     _index_thresholds = (0.2, 0.4, 0.6, 0.8)
+
+    _overlap_predicates = (predicates.commonSetElementPredicate,)
+    _overlap_thresholds = (1, 2, 3, 4)
 
     def __init__(self, definition):
         super(SetType, self).__init__(definition)

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -36,8 +36,7 @@ class ShortStringType(BaseStringType):
     type = "ShortString"
 
     _predicate_functions = (base_predicates +
-                            (predicates.suffixArray,
-                             predicates.doubleMetaphone))
+                            (predicates.doubleMetaphone,))
 
     _index_predicates = (predicates.TfidfNGramCanopyPredicate,
                          predicates.TfidfNGramSearchPredicate)
@@ -51,6 +50,7 @@ class ShortStringType(BaseStringType):
                            predicates.nearIntegersPredicate,
                            predicates.alphaNumericPredicate,
                            predicates.commonIntegerPredicate,
+                           predicates.suffixArray,
                            predicates.metaphoneToken)
     _overlap_thresholds = (1, 2, 3, 4)
 

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -1,4 +1,4 @@
-from .base import FieldType, indexPredicates
+from .base import FieldType
 from dedupe import predicates
 
 from affinegap import normalizedAffineGapDistance as affineGap
@@ -26,10 +26,10 @@ class BaseStringType(FieldType):
     def __init__(self, definition):
         super(BaseStringType, self).__init__(definition)
 
-        self.predicates += indexPredicates((predicates.LevenshteinCanopyPredicate,
-                                            predicates.LevenshteinSearchPredicate),
-                                           (1, 2, 3, 4),
-                                           self.field)
+        self.predicates += self.indexPredicates((predicates.LevenshteinCanopyPredicate,
+                                                 predicates.LevenshteinSearchPredicate),
+                                                (1, 2, 3, 4),
+                                                self.field)
 
 
 class ShortStringType(BaseStringType):
@@ -43,6 +43,17 @@ class ShortStringType(BaseStringType):
                          predicates.TfidfNGramSearchPredicate)
     _index_thresholds = (0.2, 0.4, 0.6, 0.8)
 
+    _overlap_predicates = (predicates.tokenFieldPredicate,
+                           predicates.commonFourGram,
+                           predicates.commonSixGram,
+                           predicates.hundredIntegerPredicate,
+                           predicates.hundredIntegersOddPredicate,
+                           predicates.nearIntegersPredicate,
+                           predicates.alphaNumericPredicate,
+                           predicates.commonIntegerPredicate,
+                           predicates.metaphoneToken)
+    _overlap_thresholds = (1, 2, 3, 4)
+
     def __init__(self, definition):
         super(ShortStringType, self).__init__(definition)
 
@@ -50,24 +61,6 @@ class ShortStringType(BaseStringType):
             self.comparator = crfEd
         else:
             self.comparator = affineGap
-
-        overlap_preds = [predicates.tokenFieldPredicate,
-                         predicates.commonFourGram,
-                         predicates.commonSixGram,
-                         predicates.hundredIntegerPredicate,
-                         predicates.hundredIntegersOddPredicate,
-                         predicates.nearIntegersPredicate,
-                         predicates.alphaNumericPredicate,
-                         predicates.commonIntegerPredicate,
-                         predicates.metaphoneToken]
-                             
-        for n_common in range(1, 4):
-            for pred in overlap_preds:
-                self.predicates.append(self._Predicate(pred,
-                                                       self.field,
-                                                       n_common))
-
-        
 
 class StringType(ShortStringType):
     type = "String"

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -9,17 +9,10 @@ crfEd = CRFEditDistance()
 
 base_predicates = (predicates.wholeFieldPredicate,
                    predicates.firstTokenPredicate,
-                   predicates.commonIntegerPredicate,
-                   predicates.nearIntegersPredicate,
                    predicates.firstIntegerPredicate,
-                   predicates.hundredIntegerPredicate,
-                   predicates.hundredIntegersOddPredicate,
-                   predicates.alphaNumericPredicate,
                    predicates.sameThreeCharStartPredicate,
                    predicates.sameFiveCharStartPredicate,
                    predicates.sameSevenCharStartPredicate,
-                   predicates.commonTwoTokens,
-                   predicates.commonThreeTokens,
                    predicates.fingerprint,
                    predicates.oneGramFingerprint,
                    predicates.twoGramFingerprint,
@@ -43,12 +36,8 @@ class ShortStringType(BaseStringType):
     type = "ShortString"
 
     _predicate_functions = (base_predicates +
-                            (predicates.commonFourGram,
-                             predicates.commonSixGram,
-                             predicates.tokenFieldPredicate,
-                             predicates.suffixArray,
-                             predicates.doubleMetaphone,
-                             predicates.metaphoneToken))
+                            (predicates.suffixArray,
+                             predicates.doubleMetaphone))
 
     _index_predicates = (predicates.TfidfNGramCanopyPredicate,
                          predicates.TfidfNGramSearchPredicate)
@@ -62,6 +51,23 @@ class ShortStringType(BaseStringType):
         else:
             self.comparator = affineGap
 
+        overlap_preds = [predicates.tokenFieldPredicate,
+                         predicates.commonFourGram,
+                         predicates.commonSixGram,
+                         predicates.hundredIntegerPredicate,
+                         predicates.hundredIntegersOddPredicate,
+                         predicates.nearIntegersPredicate,
+                         predicates.alphaNumericPredicate,
+                         predicates.commonIntegerPredicate,
+                         predicates.metaphoneToken]
+                             
+        for n_common in range(1, 4):
+            for pred in overlap_preds:
+                self.predicates.append(self._Predicate(pred,
+                                                       self.field,
+                                                       n_common))
+
+        
 
 class StringType(ShortStringType):
     type = "String"


### PR DESCRIPTION
## Background
In ["Dedoop: Efficient Deduplication with Hadoop"](https://dbs.uni-leipzig.de/file/Dedoop.pdf), Kolb, @andreas-thor, and Rahm propose a scheme to avoid expensive, redundant record comparisons. Their scheme can be reframed as follows:

When you block a record, attach all block_keys to the record.

```
record_id,keys
A,{1,3}
B,{1,3}
C,{2,3}
```

Then for each block, keep track of the block_keys for every record in the block that are less than or equal to the focal block key 

```
block_key, record_id, smaller_or_equal_block_keys
1,A,{1}
1,B,{1}
2,C,{2}
3,A,{1,3}
3,B,{1,3}
3,C,{2,3}
```

Finally, when it's time to compare records in a block, only compare them if the intersection of associated `smaller_block_keys` is equal to 1

So when we encounter (A,B) in block 1, we will compare the records.

But when we encounter (A,B) in block 3, we won't compare since the intersection of the associated blocks is `{1,3}` and has length of 2

But we will compare (B,C) in block 3, because `len({1,3} & {2,3)} == 1`

## Extension to multiple matching
Framed this way, it's natural to extend Kolb's scheme to only match if the intersection of block_keys is at least N instead of just 1.

For example, we may only want to compare a record pair if they share 4 words in common or 7 trigrams.

In order to achieve this, the block_keys need to include an identifier for the type of blocking rule and the number of matches required before matching.

Say block_key is a tuple of (blocking_rule_id, required_matches, block_predicate_value). Then the following algorithm will suffice:

```python
for block in blocks:
    for record_pair in block:
         record_1, record_2 = record_pair
         block_coverage = record_1.smaller_or_equal_blocks & record_2.smaller_or_equal_blocks
         current_block_key = max(block_coverage)
         current_blocking_rule_id = current_block_key[0]
         if should_compare(block_coverage, current_blocking_rule):
            score = expensive_compare(record_1, record_2)

def should_compare(block_coverage, current_blocking_rule_id):                  
     for grouped_cover in group_by_blocking_rule_id(block_coverage):
         blocking_rule_id, required_matches, _ = grouped_cover[0] # get info from arbitrary element of goruped_cover
         if blocking_rule_id != current_blocking_rule_id:
             if len(grouped_cover) >= required_matches:
                 return False #don't compare the records because they will be compared in another block with a smaller block key
         else:
             if len(grouped_cover) == required_matches:
                 return True # Now's the time compare
             else:
                 return False # Don't compare because either we haven't seen enough matches or seen too many 
```

## Jaccard Index
Prompted by a communication with Erhard Rahm, I investigated one avenue for extending this only comparing when a minimum threshold of the Jaccard index is met.

Other options
- attaching additional data to the record pairs such as cardinality of the blocks
- perhaps some of the preprocessing techniques
- using a special data structure to for filtering possible candidate records by cardinality (maybe an interval tree)