### PR TITLE
Revert "Fix OverflowError in randomPairsMatch()"

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -71,8 +71,8 @@ def randomPairsMatch(n_records_A, n_records_B, sample_size):
     if sample_size >= n:
         random_pairs = numpy.arange(n)
     else:
-        random_pairs = numpy.random.randint(
-            low=1, high=n, size=sample_size, dtype='int64')
+        random_pairs = numpy.array(random.sample(range(n), sample_size),
+                                   dtype=int)
 
     i, j = numpy.unravel_index(random_pairs, (n_records_A, n_records_B))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,23 +32,17 @@ class RandomPairsTest(unittest.TestCase):
 
     def test_random_pair_match(self):
 
-        # test 3: sample size is greater than product of A and B
-        # test 4: check for OverflowError
-        tests = ((100, 100, 100, 100), (10, 10, 99, 99),
-                 (5, 5, 100, 25), (100000, 20000, 15000, 15000))
-        for (n_A, n_B, n_sample, expected_length) in tests:
-            ret = dedupe.core.randomPairsMatch(n_A, n_B, n_sample)
-            list_ret = list(ret)
-            assert len(list_ret) == expected_length
-            for (ret_a, ret_b) in list_ret:
-                assert ret_a < n_A
-                assert ret_a >= 0
-                assert ret_b < n_B
-                assert ret_b >= 0
+        assert len(list(dedupe.core.randomPairsMatch(100, 100, 100))) == 100
+        assert len(list(dedupe.core.randomPairsMatch(10, 10, 99))) == 99
 
-        numpy.random.seed(123)
-        target = [(6, 7), (9, 3), (9, 9), (1, 8), (8, 4),
-                  (5, 8), (8, 7), (9, 8), (9, 7), (4, 8)]
+        random.seed(123)
+        random.seed(123)
+        if sys.version_info < (3, 0):
+            target = [(0, 5), (0, 8), (4, 0), (1, 0), (9, 0),
+                      (0, 3), (5, 3), (3, 3), (8, 5), (1, 5)]
+        else:
+            target = [(0, 6), (3, 4), (1, 1), (9, 8), (5, 2),
+                      (1, 3), (0, 4), (4, 8), (6, 8), (7, 1)]
 
         pairs = list(dedupe.core.randomPairsMatch(10, 10, 10))
         assert pairs == target


### PR DESCRIPTION
Reverts dedupeio/dedupe#722

If `n` is large (which it can easily be), than we will run into a 

```
ValueError: high is out of bounds for uint64 mtrand.pyx:991: ValueError
```

Python ints can be arbitrarily long. 

The previous code may also have been wrong, because when we cast the pure python to a numpy array we may have clipped the values to the max size of the numpy int type. I have to investigate further.