### PR TITLE
Add a join method to MockPool

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -365,9 +365,12 @@ def appropriate_imap(num_cores):
         imap = map
 
         # in order to make it simpler to cleanup a pool of processes
-        # always return something that we can close
+        # always return something that we can close and join
         class MockPool(object):
             def close(self):
+                pass
+
+            def join(self):
                 pass
         pool = MockPool()
     else:


### PR DESCRIPTION
A call to `pool.join()` was added in [a previous commit](https://github.com/dedupeio/dedupe/commit/da31f25bba84d23f89e4b931859979136228ab0c
) to fix a problem with spawned subprocesses launched by `StaticGazetteer.match` never exiting. (#686)


When running with a single core, `pool` is a `MockPool` instance rather than a `multiprocessing.Pool`. The `MockPool` needs to have a `join` method to avoid an unhandled `AttributeError`.

```
$python oar_gazeteer_example.py
importing data ...
N data 1 records: 5000
N data 2 records: 13972
reading from gazetteer_learned_settings
Start calculating threshold
Threshold: 0.4690942168235779
Traceback (most recent call last):
  File "oar_gazeteer_example.py", line 160, in <module>
    for matches in results:
  File "/usr/local/lib/python3.7/site-packages/dedupe/api.py", line 950, in <genexpr>
    clusters = (cluster for cluster in clusters if len(cluster))
  File "/usr/local/lib/python3.7/site-packages/dedupe/clustering.py", line 207, in gazetteMatching
    for block in scored_blocks:
  File "/usr/local/lib/python3.7/site-packages/dedupe/core.py", line 360, in scoreGazette
    pool.join()
AttributeError: 'MockPool' object has no attribute 'join'
```