### PR TITLE
fix mistake in docs for custom comparator

### DIFF
--- a/docs/Variable-definition.rst
+++ b/docs/Variable-definition.rst
@@ -100,9 +100,9 @@ For example, a custom comparator:
   def sameOrNotComparator(field_1, field_2) :     
     if field_1 and field_2 :         
         if field_1 == field_2 :             
-            return 0         
+            return 1         
         else:             
-            return 1     
+            return 0     
 
 The corresponding variable definition:
 


### PR DESCRIPTION
The values returned in the custom comparator example in the docs are the opposite of what they should be.