### PR TITLE
Made bug fix to accomodate empty keys in test data

### DIFF
--- a/dedupe/canonical.py
+++ b/dedupe/canonical.py
@@ -61,7 +61,7 @@ def getCanonicalRep(record_cluster):
         for record in record_cluster:
             # assume non-empty values always better than empty value
             # for canonical record
-            if record[key]:
+            if record.get(key):
                 key_values.append(record[key])
         if key_values:
             canonical_rep[key] = getCentroid(key_values, comparator)


### PR DESCRIPTION
Currently dedupe.io throws an error if the test data is missing a column from the training data.
We can use .get() to check if the key exists within the record to make this line failure friendly.



`
Traceback (most recent call last):
  File "~/.PyCharmCE2019.3/config/scratches/scratch.py", line 180, in <module>
    canonical_rep = dedupe.canonicalize(cluster_d)
  File "C:\Python38\lib\site-packages\dedupe\convenience.py", line 234, in canonicalize
    return getCanonicalRep(record_cluster)
  File "C:\Python38\lib\site-packages\dedupe\canonical.py", line 64, in getCanonicalRep
    if record[key]:
KeyError: 'drivers licence state'
`