### PR TITLE
Random Forest Inspired Predicate Candidates

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-
+    timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -939,7 +939,9 @@ class StaticMatching(Matching):
                 "Something has gone wrong with loading the settings file. "
                 "Try deleting the file")
 
-        logger.info(self.predicates)
+        logger.info('Predicate set:')
+        for predicate in self.predicates:
+            logger.info(predicate)
 
         self._fingerprinter = blocking.Fingerprinter(self.predicates)
 

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -71,7 +71,7 @@ class Matching(object):
         self._fingerprinter: Optional[blocking.Fingerprinter] = None
         self.data_model: datamodel.DataModel
         self.classifier: Classifier
-        self.predicates: Sequence[dedupe.predicates.Predicate]
+        self.predicates: List[dedupe.predicates.Predicate]
 
     @property
     def fingerprinter(self) -> blocking.Fingerprinter:

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1086,26 +1086,6 @@ class ActiveMatching(Matching):
         pickle.dump(self.classifier, file_obj)
         pickle.dump(self.predicates, file_obj)
 
-    def _writeIndices(self, file_obj: BinaryIO) -> None:
-        indices = {}
-        doc_to_ids = {}
-        canopies = {}
-        for full_predicate in self.predicates:
-            for predicate in full_predicate:
-                if hasattr(predicate, 'index') and predicate.index:  # type: ignore
-                    doc_to_ids[predicate] = dict(predicate.index._doc_to_id)  # type: ignore
-                    if hasattr(predicate, "canopy"):
-                        canopies[predicate] = predicate.canopy  # type: ignore
-                    else:
-                        try:
-                            indices[predicate] = predicate.index._index  # type: ignore
-                        except AttributeError:
-                            pass
-
-        pickle.dump(canopies, file_obj)
-        pickle.dump(indices, file_obj)
-        pickle.dump(doc_to_ids, file_obj)
-
     def uncertain_pairs(self) -> List[TrainingExample]:
         '''
         Returns a list of pairs of records from the sample of record pairs

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1018,7 +1018,7 @@ class ActiveMatching(Matching):
                 raise
 
     def train(self,
-              recall: float = 0.95,
+              recall: float = 1.00,
               index_predicates: bool = True) -> None:  # pragma: no cover
         """
         Learn final pairwise classifier and fingerprinting rules. Requires that

--- a/dedupe/blocking.py
+++ b/dedupe/blocking.py
@@ -22,7 +22,7 @@ def index_list():
 class Fingerprinter(object):
     '''Takes in a record and returns all blocks that record belongs to'''
 
-    def __init__(self, predicates: Iterable[dedupe.predicates.Predicate]) -> None:
+    def __init__(self, predicates: List[dedupe.predicates.Predicate]) -> None:
 
         self.predicates = predicates
 

--- a/dedupe/blocking.py
+++ b/dedupe/blocking.py
@@ -172,7 +172,7 @@ class Fingerprinter(object):
 
         for index_type, index, _ in indices:
 
-            index._index.initSearch()
+            index.initSearch()
 
             for predicate in self.index_fields[field][index_type]:
                 logger.debug("Canopy: %s", str(predicate))

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -239,7 +239,7 @@ class DedupeBlockLearner(BlockLearner):
 
         index_data = Sample(data, 50000, original_length)
         sampled_records = Sample(index_data, 5000, original_length)
-        preds = self.data_model.predicates(index_predicates=False)
+        preds = self.data_model.predicates()
 
         self.block_learner = training.DedupeBlockLearner(preds,
                                                          sampled_records,

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -395,13 +395,15 @@ class DisagreementLearner(ActiveLearner):
             self.blocker.block_learner.blocker.predicates = no_index_predicates
 
             learned_preds = self.blocker.block_learner.learn(dupes,
-                                                             recall=recall)
+                                                             recall=recall,
+                                                             candidate_types='random forest')
 
             self.blocker.block_learner.blocker.predicates = old_preds
 
         else:
             learned_preds = self.blocker.block_learner.learn(dupes,
-                                                             recall=recall)
+                                                             recall=recall,
+                                                             candidate_types='random forest')
 
         return learned_preds
 

--- a/dedupe/levenshtein.py
+++ b/dedupe/levenshtein.py
@@ -15,6 +15,7 @@ class LevenshteinIndex(Index):
             Levenshtein_search.add_string(self.index_key, doc)
 
     def unindex(self, doc):
+        raise NotImplementedError('problem in upstream library for levenshtein index')
         del self._doc_to_id[doc]
         Levenshtein_search.remove_string(self.index_key, doc)
 

--- a/dedupe/levenshtein.py
+++ b/dedupe/levenshtein.py
@@ -15,9 +15,9 @@ class LevenshteinIndex(Index):
             Levenshtein_search.add_string(self.index_key, doc)
 
     def unindex(self, doc):
-        raise NotImplementedError('problem in upstream library for levenshtein index')
         del self._doc_to_id[doc]
-        Levenshtein_search.remove_string(self.index_key, doc)
+        Levenshtein_search.clear_wordset(self.index_key)
+        self.index_key = Levenshtein_search.populate_wordset(-1, list(self._doc_to_id))
 
     def initSearch(self):
         pass

--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -12,7 +12,7 @@ from dedupe.cpredicates import ngrams, initials
 import dedupe.tfidf as tfidf
 import dedupe.levenshtein as levenshtein
 
-from typing import Sequence, Callable, Any, Tuple, Set, Iterable
+from typing import Sequence, Callable, Any, Tuple, Set
 from dedupe._typing import RecordDict
 
 words = re.compile(r"[\w']+").findall
@@ -49,7 +49,7 @@ class Predicate(abc.ABC):
         return 1
 
     @abc.abstractmethod
-    def __call__(self, record, **kwargs):
+    def __call__(self, record, **kwargs) -> tuple:
         pass
 
     def __add__(self, other: 'Predicate') -> 'CompoundPredicate':
@@ -65,12 +65,12 @@ class Predicate(abc.ABC):
 class SimplePredicate(Predicate):
     type = "SimplePredicate"
 
-    def __init__(self, func: Callable[[Any], Sequence[str]], field: str):
+    def __init__(self, func: Callable[[Any], Tuple[str, ...]], field: str):
         self.func = func
         self.__name__ = "(%s, %s)" % (func.__name__, field)
         self.field = field
 
-    def __call__(self, record: RecordDict, **kwargs) -> Iterable[str]:
+    def __call__(self, record: RecordDict, **kwargs) -> Tuple[str, ...]:
         column = record[self.field]
         if column:
             return self.func(column)

--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -68,10 +68,6 @@ class SimplePredicate(Predicate):
         else:
             return ()
 
-    def compounds_with(self, other):
-
-        return True
-
 
 class StringPredicate(SimplePredicate):
     def __call__(self, record: RecordDict, **kwargs):
@@ -81,15 +77,6 @@ class StringPredicate(SimplePredicate):
         else:
             return ()
 
-    def compounds_with(self, other):
-
-        if other.field == self.field:
-            return getattr(self.func,
-                           'compounds_with_same_field',
-                           True)
-
-        return True
-
 
 class ExistsPredicate(Predicate):
     type = "ExistsPredicate"
@@ -97,7 +84,6 @@ class ExistsPredicate(Predicate):
     def __init__(self, field):
         self.__name__ = "(Exists, %s)" % (field,)
         self.field = field
-        self.compounds_with_same_field = False
 
     @staticmethod
     def func(column):
@@ -110,13 +96,6 @@ class ExistsPredicate(Predicate):
         column = record[self.field]
         return self.func(column)
 
-    def compounds_with(self, other):
-
-        if self.field == other.field:
-            return False
-
-        return True
-
 
 class IndexPredicate(Predicate):
     def __init__(self, threshold, field):
@@ -124,7 +103,6 @@ class IndexPredicate(Predicate):
         self.field = field
         self.threshold = threshold
         self.index = None
-        self.compounds_with_same_field = False
 
     def __getstate__(self):
         odict = self.__dict__.copy()
@@ -137,14 +115,6 @@ class IndexPredicate(Predicate):
         # backwards compatibility
         if not hasattr(self, 'index'):
             self.index = None
-
-    def compounds_with(self, other):
-
-        if other.field == self.field:
-            if type(other) == type(self):
-                return False
-
-        return True
 
     def reset(self):
         ...
@@ -347,9 +317,6 @@ def wholeFieldPredicate(field: Any) -> Tuple[str]:
     return (str(field), )
 
 
-wholeFieldPredicate.compounds_with_same_field = False  # type: ignore
-
-
 def tokenFieldPredicate(field):
     """returns the tokens"""
     return set(words(field))
@@ -466,9 +433,6 @@ def suffixArray(field):
             yield field[i:]
 
 
-suffixArray.compounds_with_same_field = False  # type: ignore
-
-
 def sortedAcronym(field: str) -> Tuple[str]:
     return (''.join(sorted(each[0] for each in field.split())),)
 
@@ -486,9 +450,6 @@ def metaphoneToken(field):
 
 def wholeSetPredicate(field_set):
     return (str(field_set),)
-
-
-wholeSetPredicate.compounds_with_same_field = False  # type: ignore
 
 
 def commonSetElementPredicate(field_set):

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -106,9 +106,9 @@ class BlockLearner(ABC):
                                   for pred, pairs
                                   in match_cover.items()}
 
-            # initialize an empty predicate that will be
-            # the base for the k-conjunctions
-            candidate = CompoundPredicate()
+            # initialize variables that will be
+            # the base for the constructing k-conjunctions
+            candidate = None
             covered_comparisons = InfiniteSet()
             covered_matches = InfiniteSet()
             covered_sample_matches = InfiniteSet()
@@ -124,7 +124,10 @@ class BlockLearner(ABC):
 
             for _ in range(K):
                 next_predicate = max(sample_predicates, key=score)
-                candidate += next_predicate
+                if candidate:
+                    candidate += next_predicate
+                else:
+                    candidate = next_predicate
 
                 covered_comparisons &= comparison_cover[next_predicate]
                 candidate.count = self.estimate(covered_comparisons)  # type: ignore

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -15,7 +15,7 @@ from typing import (Dict, Sequence, Iterable, Tuple, List,
                     FrozenSet)
 
 from . import blocking, core
-from .predicates import CompoundPredicate, Predicate
+from .predicates import Predicate
 
 logger = logging.getLogger(__name__)
 

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -110,13 +110,15 @@ class BlockLearner(ABC):
             # the base for the k-conjunctions
             candidate = CompoundPredicate()
             covered_comparisons = InfiniteSet()
-            covered_matches = frozenset(matches)
+            covered_matches = InfiniteSet()
             covered_sample_matches = InfiniteSet()
 
             def score(predicate: Predicate) -> float:
                 try:
-                    return (len(covered_sample_matches & sample_match_cover[predicate]) /
-                            self.estimate(covered_comparisons & comparison_cover[predicate]))
+                    return (len(covered_sample_matches &
+                                sample_match_cover[predicate]) /
+                            self.estimate(covered_comparisons &
+                                          comparison_cover[predicate]))
                 except ZeroDivisionError:
                     return 0.
 
@@ -390,11 +392,6 @@ class Resampler(object):
                                                for k in iterable
                                                if k in self.replacements)
         return frozenset(result)
-
-    @property
-    def pairs(self) -> frozenset:
-
-        return frozenset(itertools.chain.from_iterable(self.replacements.values()))
 
 
 OUT_OF_PREDICATES_WARNING = "Ran out of predicates: Dedupe tries to find blocking rules that will work well with your data. Sometimes it can't find great ones, and you'll get this warning. It means that there are some pairs of true records that dedupe may never compare. If you are getting bad results, try increasing the `max_comparison` argument to the train method"  # noqa: E501

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -47,8 +47,8 @@ class BlockLearner(ABC):
         else:
             epsilon -= len(uncoverable_dupes)
 
-        candidate_cover = self.generate_candidates_rf(match_cover,
-                                                      comparison_cover)
+        candidate_cover = self.generate_candidates(match_cover,
+                                                   comparison_cover)
 
         searcher = BranchBound(len(coverable_dupes) - epsilon, 2500)
         final_predicates = searcher.search(candidate_cover)
@@ -59,38 +59,9 @@ class BlockLearner(ABC):
 
         return final_predicates
 
-    def generate_candidates_bilenko(self,
-                                    match_cover: dict,
-                                    comparison_cover: dict) -> dict:
-        predicates = list(match_cover)
-        candidates = {}
-        K = 3
-
-        for i, predicate in enumerate(predicates):
-            current_match_cover = match_cover[predicate]
-            current_comparison_cover = comparison_cover[predicate]
-            predicate.count = self.estimate(current_comparison_cover)
-            candidates[predicate] = current_match_cover
-            remaining = predicates
-            predicate = CompoundPredicate(predicate,)
-            for _ in range(K):
-                if not remaining:
-                    break
-                best_p = max(remaining,
-                             key=lambda x: (len(current_match_cover & match_cover[x]) /
-                                            (self.estimate(current_comparison_cover & comparison_cover[x]) or float('inf'))))
-                predicate += best_p
-                current_match_cover &= match_cover[best_p]
-                current_comparison_cover &= comparison_cover[best_p]
-                predicate.count = self.estimate(current_comparison_cover)  # type: ignore
-                candidates[predicate] = current_match_cover
-                remaining.remove(best_p)
-
-        return candidates
-
-    def generate_candidates_rf(self,
-                               match_cover: Cover,
-                               comparison_cover: Cover) -> Cover:
+    def generate_candidates(self,
+                            match_cover: Cover,
+                            comparison_cover: Cover) -> Cover:
         predicates = list(match_cover)
         matches = list(frozenset.union(*match_cover.values()))
         pred_sample_size = max(int(math.sqrt(len(predicates))), 5)

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -77,7 +77,7 @@ class BlockLearner(ABC):
                 predicate = CompoundPredicate(predicate + (best_p,))
                 current_match_cover &= match_cover[best_p]
                 current_comparison_cover &= comparison_cover[best_p]
-                predicate.count = self.estimate(current_comparison_cover)
+                predicate.count = self.estimate(current_comparison_cover)  # type: ignore
                 candidates[predicate] = current_match_cover
                 remaining.remove(best_p)
 
@@ -109,7 +109,7 @@ class BlockLearner(ABC):
                 current_match_cover &= expander(match_cover[best_p])
                 real_match_cover &= match_cover[best_p]
                 current_comparison_cover &= comparison_cover[best_p]
-                predicate.count = self.estimate(current_comparison_cover)
+                predicate.count = self.estimate(current_comparison_cover)  # type: ignore
                 candidates[predicate] = real_match_cover
                 sample_predicates.remove(best_p)
 

--- a/tests/canonical_gazetteer.py
+++ b/tests/canonical_gazetteer.py
@@ -95,8 +95,13 @@ if __name__ == '__main__':
             gazetteer.write_settings(f)
 
     gazetteer.index(data_2)
-    gazetteer.unindex(data_2)
-    gazetteer.index(data_2)
+    try:
+        gazetteer.unindex(data_2)
+    except NotImplementedError:
+        gazetteer.fingerprinter.reset_indices()
+        gazetteer.index(data_2)
+    else:
+        gazetteer.index(data_2)
 
     # print candidates
     print('clustering...')

--- a/tests/canonical_gazetteer.py
+++ b/tests/canonical_gazetteer.py
@@ -95,13 +95,8 @@ if __name__ == '__main__':
             gazetteer.write_settings(f)
 
     gazetteer.index(data_2)
-    try:
-        gazetteer.unindex(data_2)
-    except NotImplementedError:
-        gazetteer.fingerprinter.reset_indices()
-        gazetteer.index(data_2)
-    else:
-        gazetteer.index(data_2)
+    gazetteer.unindex(data_2)
+    gazetteer.index(data_2)
 
     # print candidates
     print('clustering...')

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -19,8 +19,8 @@ class ActiveLearningTest(unittest.TestCase):
     def test_AL(self):
         random.seed(1111111111110)
         original_N = len(SAMPLE)
-        active_learner = dedupe.labeler.DedupeRLRLearner(self.data_model,
-                                                         candidates=SAMPLE)
+        active_learner = dedupe.labeler.RLRLearner(self.data_model)
+        active_learner.candidates = SAMPLE
         assert len(active_learner) == original_N
         pair = active_learner.pop()
         print(pair)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -63,28 +63,6 @@ class TrainingTest(unittest.TestCase):
         assert training.BranchBound.uncovered_by(before, {3}) == after
         assert before == before_copy
 
-    def test_compound(self):
-        start = training.Cover({1: {1, 2, 3}, 2: {1, 2}, 3: {2}, 4: {5}})
-        before = start.copy()
-        after = before.copy()
-        after.update({(1, 2): {1, 2},
-                      (1, 3): {2},
-                      (2, 3): {2}})
-
-        before.compound(2)
-        assert before == after
-
-        before = start.copy()
-        after = start.copy()
-        after.update({(1, 2): {1, 2},
-                      (1, 3): {2},
-                      (2, 3): {2},
-                      (1, 2, 3): {2}})
-
-        before.compound(3)
-
-        assert before == after
-
     def test_covered_pairs(self):
         p1 = lambda x, target=None: (1,)  # noqa: E 731
 


### PR DESCRIPTION
Our current block learner proceeds as follows

1. Calculate the coverage and comparison cost for all compound predicates of length 1 and 2
2. For this set of predicates, use Branch and Bound to find the subset that covers all the co-referent pairs and has the lowest total comparisons

It would be good to consider compound predicates of length 3 and higher, but this is not feasible to use our current procedure because of the combinatorial explosion.

This PR takes an approach inspired by random forests.

1. take a subsample of co-referent records and subsample of simple predicates, greedily find the best predicate of length k for these values
2. repeat sampling to produce candidate set
3. use Branch and Bound with that candidate set to find good subset.

many thanks to @tarakc02 for thinking through this with me.
