### PR TITLE
Don't raise AssertionError when out of candidates

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1037,7 +1037,8 @@ class ActiveMatching(Matching):
                               and take substantial memory.
 
         """
-        assert self.active_learner, "Please initialize with the sample method"
+        assert self.active_learner is not None, \
+               "Please initialize with the sample method"
 
         examples, y = flatten_training(self.training_pairs)
         self.classifier.fit(self.data_model.distances(examples), y)
@@ -1119,7 +1120,8 @@ class ActiveMatching(Matching):
           [({'name' : 'Georgie Porgie'}, {'name' : 'Georgette Porgette'})]
 
         '''
-        assert self.active_learner, "Please initialize with the sample method"
+        assert self.active_learner is not None, \
+               "Please initialize with the sample method"
         return [self.active_learner.pop()]
 
     def mark_pairs(self, labeled_pairs: TrainingData) -> None:

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -39,10 +39,10 @@ def console_label(deduper: dedupe.api.ActiveMatching) -> None:  # pragma: no cov
             record_pair, _ = examples_buffer.pop(0)
             use_previous = False
         else:
-            if not uncertain_pairs:
-                uncertain_pairs = deduper.uncertain_pairs()
-
             try:
+                if not uncertain_pairs:
+                    uncertain_pairs = deduper.uncertain_pairs()
+
                 record_pair = uncertain_pairs.pop()
             except IndexError:
                 break


### PR DESCRIPTION
Fix a bug where AssertionError was raised indicating that an instance
should be initialized with `sample()`, even though the instance is
already initialized. The problem is that some learners (like the
`DisagreementLearner`) define the `__len__()` method, returning the
number of candidates. However this means that the assertion could fail
if the learner ran out of candidates. Fix that by asserting explicitly
that the variable is not None.

Also, since `uncertain_pairs()` can raise IndexError when no candidates
exist, handle this case in `console_label()` too, just like we already
do when we `pop()` from `uncertain_pairs`.