### PR TITLE
docs: fix simple typo, probabilites -> probabilities

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -93,7 +93,7 @@ class IntegralMatching(Matching):
               pairs: RecordPairs) -> numpy.ndarray:
         """
         Scores pairs of records. Returns pairs of tuples of records id and
-        associated probabilites that the pair of records are match
+        associated probabilities that the pair of records are match
 
         Args:
             pairs: Iterator of pairs of records


### PR DESCRIPTION
There is a small typo in dedupe/api.py.

Should read `probabilities` rather than `probabilites`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md