### PR TITLE
implements `return_confidence_scores` as argument to clustering

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -256,15 +256,16 @@ class DedupeMatching(IntegralMatching):
             pairs.close()
             con.close()
 
-    def cluster(self,
-                scores: numpy.ndarray,
-                threshold: float = 0.5) -> Clusters:
+    def cluster(self, scores: numpy.ndarray,
+                threshold: float = 0.5,
+                return_confidence_scores: bool = True) -> Clusters:
         r"""From the similarity scores of pairs of records, decide which groups
         of records are all referring to the same entity.
 
         Yields tuples containing a sequence of record ids and corresponding
-        sequence of confidence score as a float between 0 and 1. The
-        record_ids within each set should refer to the same entity and the
+        sequence of confidence score as a float between 0 and 1 (if return_confidence_scores
+        is set to True). Setting return_confidence_scores to False speeds up clustering.
+        The record_ids within each set should refer to the same entity and the
         confidence score is a measure of our confidence a particular entity
         belongs in the cluster.
 
@@ -322,7 +323,7 @@ class DedupeMatching(IntegralMatching):
 
         logger.debug("matching done, begin clustering")
 
-        yield from clustering.cluster(scores, threshold)
+        yield from clustering.cluster(scores, threshold, return_confidence_scores)
 
 
 class RecordLinkMatching(IntegralMatching):

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -195,6 +195,7 @@ def condensedDistance(dupes: numpy.ndarray) -> Tuple[Dict[int, RecordID],
 
 def cluster(dupes: numpy.ndarray,
             threshold: float = .5,
+            return_confidence_scores: bool = True,
             max_components: int = 30000) -> Clusters:
     '''
     Takes in a list of duplicate pairs and clusters them in to a
@@ -205,6 +206,8 @@ def cluster(dupes: numpy.ndarray,
     threshold -- number betweent 0 and 1 (default is .5). lowering the
                  number will increase precision, raising it will increase
                  recall
+    return_confidence_scores -- boolean to indicate whether confidence scores should be returned
+                Turning off confidence scores significantly speeds up clustering.
     '''
     distance_threshold = 1 - threshold
     dupe_sub_graphs = connected_components(dupes, max_components)
@@ -229,7 +232,10 @@ def cluster(dupes: numpy.ndarray,
 
             for cluster in clusters.values():
                 if len(cluster) > 1:
-                    scores = confidences(cluster, condensed_distances, N)
+                    if return_confidence_scores:
+                        scores = confidences(cluster, condensed_distances, N)
+                    else:
+                        scores = None
                     yield tuple(i_to_id[i] for i in cluster), scores
 
         else:


### PR DESCRIPTION
We found that the confidence score calculation was very time consuming when using dedupe with large data. This pull request implements a `return_confidence_scores` argument in the cluster function that defaults to True. It allows the user to set it to False to gain significant speed improvements when confidence scores are not required.