### PR TITLE
implements firstTwoTokensPredicate

### DIFF
--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -18,7 +18,7 @@ from dedupe._typing import RecordDict
 words = re.compile(r"[\w']+").findall
 integers = re.compile(r"\d+").findall
 start_word = re.compile(r"^([\w']+)").match
-two_start_words = re.compile(r"^[\w']+(\s+[\w']+)?").match
+two_start_words = re.compile(r"^([\w']+\s+[\w']+)").match
 start_integer = re.compile(r"^(\d+)").match
 alpha_numeric = re.compile(r"(?=\w*\d)[a-zA-Z\d]+").findall
 
@@ -358,7 +358,7 @@ def firstTokenPredicate(field: str) -> Sequence[str]:
 def firstTwoTokensPredicate(field: str) -> Sequence[str]:
     first_two_tokens = two_start_words(field)
     if first_two_tokens:
-        return (first_two_tokens.group(),)
+        return first_two_tokens.groups()
     else:
         return ()
 

--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -18,6 +18,7 @@ from dedupe._typing import RecordDict
 words = re.compile(r"[\w']+").findall
 integers = re.compile(r"\d+").findall
 start_word = re.compile(r"^([\w']+)").match
+two_start_words = re.compile(r"^[\w']+(\s+[\w']+)?").match
 start_integer = re.compile(r"^(\d+)").match
 alpha_numeric = re.compile(r"(?=\w*\d)[a-zA-Z\d]+").findall
 
@@ -350,6 +351,14 @@ def firstTokenPredicate(field: str) -> Sequence[str]:
     first_token = start_word(field)
     if first_token:
         return first_token.groups()
+    else:
+        return ()
+
+
+def firstTwoTokensPredicate(field: str) -> Sequence[str]:
+    first_two_tokens = two_start_words(field)
+    if first_two_tokens:
+        return (first_two_tokens.group(),)
     else:
         return ()
 

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -11,6 +11,7 @@ crfEd = CRFEditDistance()
 
 base_predicates = (predicates.wholeFieldPredicate,
                    predicates.firstTokenPredicate,
+                   predicates.firstTwoTokensPredicate,
                    predicates.commonIntegerPredicate,
                    predicates.nearIntegersPredicate,
                    predicates.firstIntegerPredicate,

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -237,8 +237,9 @@ class PredicatesTest(unittest.TestCase):
         assert dedupe.predicates.firstTokenPredicate('') == ()
         assert dedupe.predicates.firstTokenPredicate('123/') == ('123',)
         assert dedupe.predicates.firstTwoTokensPredicate(field) == ('123 16th',)
+        assert dedupe.predicates.firstTwoTokensPredicate('oneword') == ()
         assert dedupe.predicates.firstTwoTokensPredicate('') == ()
-        assert dedupe.predicates.firstTwoTokensPredicate('123/') == ('123',)
+        assert dedupe.predicates.firstTwoTokensPredicate('123 456/') == ('123 456',)
         assert dedupe.predicates.tokenFieldPredicate(' ') == set([])
         assert dedupe.predicates.tokenFieldPredicate(
             field) == set(['123', '16th', 'st'])

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -236,6 +236,9 @@ class PredicatesTest(unittest.TestCase):
         assert dedupe.predicates.firstTokenPredicate(field) == ('123',)
         assert dedupe.predicates.firstTokenPredicate('') == ()
         assert dedupe.predicates.firstTokenPredicate('123/') == ('123',)
+        assert dedupe.predicates.firstTwoTokensPredicate(field) == ('123 16th',)
+        assert dedupe.predicates.firstTwoTokensPredicate('') == ()
+        assert dedupe.predicates.firstTwoTokensPredicate('123/') == ('123',)
         assert dedupe.predicates.tokenFieldPredicate(' ') == set([])
         assert dedupe.predicates.tokenFieldPredicate(
             field) == set(['123', '16th', 'st'])


### PR DESCRIPTION
I found that often the two words of a company or person name are equal and therefore this appeared to be a good blocking rule. Since it is more restrictive than the firstTokenPredicate, the number of pairwise comparisons that needs to be made are reduced drastically when this predicate is selected.