### PR TITLE
remove code used to calculate the total comparisons of predicate

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1206,8 +1206,7 @@ class Dedupe(ActiveMatching, DedupeMatching):
                          data: Data,
                          training_file: TextIO = None,
                          sample_size: int = 1500,
-                         blocked_proportion: float = 0.9,
-                         original_length: int = None) -> None:
+                         blocked_proportion: float = 0.9) -> None:
         '''
         Initialize the active learner with your data and, optionally,
         existing training data.
@@ -1221,11 +1220,6 @@ class Dedupe(ActiveMatching, DedupeMatching):
             training_file: file object containing training data
             sample_size: Size of the sample to draw
             blocked_proportion: The proportion of record pairs to be sampled from similar records, as opposed to randomly selected pairs. Defaults to 0.9.
-            original_length: If `data` is a subsample of all your data,
-                             `original_length` should be the size of
-                             your complete data. By default,
-                             `original_length` defaults to the length of
-                             `data`.
 
         .. code:: python
 
@@ -1240,13 +1234,12 @@ class Dedupe(ActiveMatching, DedupeMatching):
 
         if training_file:
             self._read_training(training_file)
-        self._sample(data, sample_size, blocked_proportion, original_length)
+        self._sample(data, sample_size, blocked_proportion)
 
     def _sample(self,
                 data: Data,
                 sample_size: int = 15000,
-                blocked_proportion: float = 0.5,
-                original_length: int = None) -> None:
+                blocked_proportion: float = 0.5) -> None:
         '''Draw a sample of record pairs from the dataset
         (a mix of random pairs & pairs of similar records)
         and initialize active learning with this sample
@@ -1260,14 +1253,8 @@ class Dedupe(ActiveMatching, DedupeMatching):
 
         :param blocked_proportion: Proportion of the sample that will be blocked
 
-        :param original_length: Length of original data, should be set
-                                if `data` is a sample of full data
-
         '''
         self._checkData(data)
-
-        if not original_length:
-            original_length = len(data)
 
         # We need the active learner to know about all our
         # existing training data, so add them to data dictionary
@@ -1277,7 +1264,6 @@ class Dedupe(ActiveMatching, DedupeMatching):
                                                  data,
                                                  blocked_proportion,
                                                  sample_size,
-                                                 original_length,
                                                  index_include=examples)
 
         self.active_learner.mark(examples, y)
@@ -1303,9 +1289,7 @@ class Link(ActiveMatching):
                          data_2: Data,
                          training_file: Optional[TextIO] = None,
                          sample_size: int = 15000,
-                         blocked_proportion: float = 0.5,
-                         original_length_1: Optional[int] = None,
-                         original_length_2: Optional[int] = None) -> None:
+                         blocked_proportion: float = 0.5) -> None:
         '''
         Initialize the active learner with your data and, optionally,
         existing training data.
@@ -1324,16 +1308,6 @@ class Link(ActiveMatching):
                                 be sampled from similar records,
                                 as opposed to randomly selected
                                 pairs. Defaults to 0.5.
-            original_length_1: If `data_1` is a subsample of your first dataset,
-                               `original_length_1` should be the size of
-                               the complete first dataset. By default,
-                               `original_length_1` defaults to the length of
-                               `data_1`
-            original_length_2: If `data_2` is a subsample of your first dataset,
-                               `original_length_2` should be the size of
-                               the complete first dataset. By default,
-                               `original_length_2` defaults to the length of
-                               `data_2`
 
         .. code:: python
 
@@ -1349,17 +1323,13 @@ class Link(ActiveMatching):
         self._sample(data_1,
                      data_2,
                      sample_size,
-                     blocked_proportion,
-                     original_length_1,
-                     original_length_2)
+                     blocked_proportion)
 
     def _sample(self,
                 data_1: Data,
                 data_2: Data,
                 sample_size: int = 15000,
-                blocked_proportion: float = 0.5,
-                original_length_1: int = None,
-                original_length_2: int = None) -> None:
+                blocked_proportion: float = 0.5) -> None:
         '''
         Draws a random sample of combinations of records from
         the first and second datasets, and initializes active
@@ -1383,8 +1353,6 @@ class Link(ActiveMatching):
                                                  data_2,
                                                  blocked_proportion,
                                                  sample_size,
-                                                 original_length_1,
-                                                 original_length_2,
                                                  index_include=examples)
 
         self.active_learner.mark(examples, y)

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -182,13 +182,13 @@ def condensedDistance(dupes: numpy.ndarray) -> Tuple[Dict[int, RecordID],
     col = ids[:, 1]
 
     N = len(candidate_set)
-    matrix_length = N * (N - 1) / 2
+    matrix_length = N * (N - 1) // 2
 
-    row_step = (N - row) * (N - row - 1) / 2
+    row_step = (N - row) * (N - row - 1) // 2
     index = matrix_length - row_step + col - row - 1
 
-    condensed_distances = numpy.ones(int(matrix_length), 'f4')
-    condensed_distances[index.astype(int)] = 1 - dupes['score']
+    condensed_distances = numpy.ones(matrix_length, 'f4')
+    condensed_distances[index] = 1 - dupes['score']
 
     return i_to_id, condensed_distances, N
 
@@ -247,12 +247,11 @@ def confidences(cluster: Sequence[int],
     used to calculate the standard deviation of an entire cluster,
     which is a reasonable metric for clusters.
     '''
-
     scores_d = dict.fromkeys(cluster, 0.0)
     squared_distances = condensed_distances ** 2
     for i, j in itertools.combinations(cluster, 2):
-        index = d * (d - 1) / 2 - (d - i) * (d - i - 1) / 2 + j - i - 1
-        squared_dist = squared_distances[int(index)]
+        index = d * (d - 1) // 2 - (d - i) * (d - i - 1) // 2 + j - i - 1
+        squared_dist = squared_distances[index]
         scores_d[i] += squared_dist
         scores_d[j] += squared_dist
     scores = numpy.array([score for _, score in sorted(scores_d.items())])

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -395,9 +395,31 @@ def index(data: Mapping[Any, Any], offset: int = 0) -> Mapping[int, Any]:
                         data.values()))
         return data
 
-
+    
 def Enumerator(start: int = 0, initial: tuple = ()) -> collections.defaultdict:
     return collections.defaultdict(itertools.count(start).__next__, initial)
+
+
+class DiagonalEnumerator(object):
+    def __init__(self, N : int):
+        self.N = N
+        self.C = N * (N - 1) / 2 - 1
+
+    def __getitem__(self, pair: Tuple[int, int]) -> int:
+        x, y = pair
+        N = self.N
+        C = self.C
+        z = C - (N - x) * (N - x - 1) / 2 + y - x
+        return int(z)
+
+
+class FullEnumerator(object):
+    def __init__(self, width : int):
+        self.width = width
+
+    def __getitem__(self, pair: Tuple[int, int]) -> int:
+        x, y = pair
+        return x * self.width + y
 
 
 def sniff_id_type(ids: Sequence[Tuple[RecordID, RecordID]]) -> Union[Type[int], Tuple[Type[str], int]]:

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -395,13 +395,13 @@ def index(data: Mapping[Any, Any], offset: int = 0) -> Mapping[int, Any]:
                         data.values()))
         return data
 
-    
+
 def Enumerator(start: int = 0, initial: tuple = ()) -> collections.defaultdict:
     return collections.defaultdict(itertools.count(start).__next__, initial)
 
 
 class DiagonalEnumerator(object):
-    def __init__(self, N : int):
+    def __init__(self, N: int):
         self.N = N
         self.C = N * (N - 1) / 2 - 1
 
@@ -414,7 +414,7 @@ class DiagonalEnumerator(object):
 
 
 class FullEnumerator(object):
-    def __init__(self, width : int):
+    def __init__(self, width: int):
         self.width = width
 
     def __getitem__(self, pair: Tuple[int, int]) -> int:

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -51,7 +51,7 @@ def randomPairs(n_records: int, sample_size: int) -> IndicesIterator:
     http://stackoverflow.com/a/14839010/98080
 
     """
-    n: int = int(n_records * (n_records - 1) / 2)
+    n: int = n_records * (n_records - 1) // 2
 
     if sample_size >= n:
         random_pairs = numpy.arange(n, dtype='uint')
@@ -64,10 +64,10 @@ def randomPairs(n_records: int, sample_size: int) -> IndicesIterator:
 
     b: int = 1 - 2 * n_records
 
-    root = (-b - 2 * numpy.sqrt(2 * (n - random_pairs) + 0.25)) / 2
+    root = (-b - 2 * numpy.sqrt(2 * (n - random_pairs) + 0.25)) // 2
 
-    i = numpy.floor(root).astype('uint')
-    j = numpy.rint(random_pairs + i * (b + i + 2) / 2 + 1).astype('uint')
+    i = root.astype('uint')
+    j = (random_pairs + i * (b + i + 2) // 2 + 1).astype('uint')
 
     return zip(i, j)
 
@@ -76,7 +76,7 @@ def randomPairsMatch(n_records_A: int, n_records_B: int, sample_size: int) -> In
     """
     Return random combinations of indices for record list A and B
     """
-    n: int = int(n_records_A * n_records_B)
+    n: int = n_records_A * n_records_B
 
     if sample_size >= n:
         random_pairs = numpy.arange(n)
@@ -403,14 +403,13 @@ def Enumerator(start: int = 0, initial: tuple = ()) -> collections.defaultdict:
 class DiagonalEnumerator(object):
     def __init__(self, N: int):
         self.N = N
-        self.C = N * (N - 1) / 2 - 1
+        self.C = N * (N - 1) // 2 - 1
 
     def __getitem__(self, pair: Tuple[int, int]) -> int:
         x, y = pair
         N = self.N
         C = self.C
-        z = C - (N - x) * (N - x - 1) / 2 + y - x
-        return int(z)
+        return C - (N - x) * (N - x - 1) // 2 + y - x
 
 
 class FullEnumerator(object):

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -248,12 +248,11 @@ class DedupeBlockLearner(BlockLearner):
     def __init__(self, data_model,
                  candidates,
                  data,
-                 original_length,
                  index_include):
         super().__init__(data_model, candidates)
 
-        index_data = Sample(data, 50000, original_length)
-        sampled_records = Sample(index_data, 5000, original_length)
+        index_data = Sample(data, 50000)
+        sampled_records = Sample(index_data, 5000)
         preds = self.data_model.predicates()
 
         self.block_learner = training.DedupeBlockLearner(preds,
@@ -287,15 +286,13 @@ class RecordLinkBlockLearner(BlockLearner):
                  candidates,
                  data_1,
                  data_2,
-                 original_length_1,
-                 original_length_2,
                  index_include):
 
         super().__init__(data_model, candidates)
 
-        sampled_records_1 = Sample(data_1, 600, original_length_1)
-        index_data = Sample(data_2, 50000, original_length_2)
-        sampled_records_2 = Sample(index_data, 600, original_length_2)
+        sampled_records_1 = Sample(data_1, 600)
+        index_data = Sample(data_2, 50000)
+        sampled_records_2 = Sample(index_data, 600)
 
         preds = self.data_model.predicates(canopies=False)
 
@@ -415,7 +412,6 @@ class DedupeDisagreementLearner(DedupeSampler, DisagreementLearner):
                  data,
                  blocked_proportion,
                  sample_size,
-                 original_length,
                  index_include):
 
         self.data_model = data_model
@@ -433,7 +429,6 @@ class DedupeDisagreementLearner(DedupeSampler, DisagreementLearner):
         self.blocker = DedupeBlockLearner(data_model,
                                           self.candidates,
                                           data,
-                                          original_length,
                                           index_include)
         self.classifier = RLRLearner(self.data_model)
         self.classifier.candidates = self.candidates
@@ -452,8 +447,6 @@ class RecordLinkDisagreementLearner(RecordLinkSampler, DisagreementLearner):
                  data_2,
                  blocked_proportion,
                  sample_size,
-                 original_length_1,
-                 original_length_2,
                  index_include):
 
         self.data_model = data_model
@@ -478,8 +471,6 @@ class RecordLinkDisagreementLearner(RecordLinkSampler, DisagreementLearner):
                                               self.candidates,
                                               data_1,
                                               data_2,
-                                              original_length_1,
-                                              original_length_2,
                                               index_include)
         self.classifier = RLRLearner(self.data_model)
         self.classifier.candidates = self.candidates
@@ -492,13 +483,9 @@ class RecordLinkDisagreementLearner(RecordLinkSampler, DisagreementLearner):
 
 class Sample(dict):
 
-    def __init__(self, d, sample_size, original_length):
+    def __init__(self, d, sample_size):
         if len(d) <= sample_size:
             super().__init__(d)
         else:
             sample = random.sample(d.keys(), sample_size)
             super().__init__({k: d[k] for k in sample})
-        if original_length is None:
-            self.original_length = len(d)
-        else:
-            self.original_length = original_length

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -8,7 +8,7 @@ import logging
 import collections
 import functools
 import random
-from abc import ABC, abstractmethod
+from abc import ABC
 import math
 
 from typing import (Dict, Sequence, Iterable, Tuple, List,

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -156,8 +156,8 @@ class DedupeBlockLearner(BlockLearner):
     def coveredPairs(blocker, records):
         cover = {}
 
-        pair_enumerator = core.Enumerator()
         n_records = len(records)
+        pair_enumerator = core.DiagonalEnumerator(n_records)
 
         for predicate in blocker.predicates:
             pred_cover = collections.defaultdict(set)
@@ -197,7 +197,7 @@ class RecordLinkBlockLearner(BlockLearner):
     def coveredPairs(self, blocker, records_1, records_2):
         cover = {}
 
-        pair_enumerator = core.Enumerator()
+        pair_enumerator = core.FullEnumerator(len(records_2))
 
         for predicate in blocker.predicates:
             cover[predicate] = collections.defaultdict(lambda: (set(), set()))

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -247,7 +247,6 @@ class BranchBound(object):
 
         if covered >= self.target:
             if score < self.cheapest_score:
-                print(score)
                 self.cheapest = partial
                 self.cheapest_score = score
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,8 +2,6 @@ import dedupe
 import dedupe.api
 import unittest
 import itertools
-import random
-import numpy
 import warnings
 from collections import OrderedDict
 
@@ -91,37 +89,6 @@ class ActiveMatch(unittest.TestCase):
             assert len(w) == 1
             assert str(
                 w[-1].message) == "Didn't return any labeled record pairs"
-
-
-class DedupeTest(unittest.TestCase):
-    def setUp(self):
-        random.seed(123)
-        numpy.random.seed(456)
-
-        field_definition = [{'field': 'name', 'type': 'String'},
-                            {'field': 'age', 'type': 'String'}]
-
-        self.deduper = dedupe.Dedupe(field_definition)
-
-    def test_randomSample(self):
-
-        random.seed(7)
-        numpy.random.seed(7)
-        self.deduper._sample(data_dict, 30, 1)
-
-        correct_result = [({'age': '50', 'name': 'Linda'},
-                           {'age': '51', 'name': 'bob belcher'}),
-                          ({'age': '51', 'name': 'Bob'},
-                           {'age': '51', 'name': 'Bob B.'}),
-                          ({'age': '51', 'name': 'Bob'},
-                           {'age': '51', 'name': 'bob belcher'}),
-                          ({'age': '51', 'name': 'Bob B.'},
-                           {'age': '51', 'name': 'bob belcher'}),
-                          ({'age': '50', 'name': 'Linda'},
-                           {'age': '50', 'name': 'linda '})]
-
-        for pair in correct_result:
-            assert pair in self.deduper.active_learner.candidates
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
this code just ends of multiplying the number of records pairs from a sample that are covered by a predicate by constant. that constant shouldn't change the outcome of the blocker learner at all.