### PR TITLE
pre-compute squared_distances

### DIFF
--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -212,6 +212,7 @@ def cluster(dupes: numpy.ndarray,
         if len(sub_graph) > 1:
 
             i_to_id, condensed_distances, N = condensedDistance(sub_graph)
+            squared_distances = condensed_distances**2
 
             linkage = fastcluster.linkage(condensed_distances,
                                           method='centroid',
@@ -228,7 +229,7 @@ def cluster(dupes: numpy.ndarray,
 
             for cluster in clusters.values():
                 if len(cluster) > 1:
-                    scores = confidences(cluster, condensed_distances, N)
+                    scores = confidences(cluster, squared_distances, N)
                     yield tuple(i_to_id[i] for i in cluster), scores
 
         else:
@@ -238,7 +239,7 @@ def cluster(dupes: numpy.ndarray,
 
 
 def confidences(cluster: Sequence[int],
-                condensed_distances: numpy.ndarray,
+                squared_distances: numpy.ndarray,
                 d: int) -> numpy.ndarray:
     '''
     We calculate a per record score that is similar to a standard
@@ -247,7 +248,6 @@ def confidences(cluster: Sequence[int],
     which is a reasonable metric for clusters.
     '''
     scores_d = dict.fromkeys(cluster, 0.0)
-    squared_distances = condensed_distances ** 2
     C = 2 * d - 3
     for i, j in itertools.combinations(cluster, 2):
         index = i * (C - i) // 2 + j - 1

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -212,7 +212,6 @@ def cluster(dupes: numpy.ndarray,
         if len(sub_graph) > 1:
 
             i_to_id, condensed_distances, N = condensedDistance(sub_graph)
-            squared_distances = condensed_distances**2
 
             linkage = fastcluster.linkage(condensed_distances,
                                           method='centroid',
@@ -227,6 +226,7 @@ def cluster(dupes: numpy.ndarray,
             for i, cluster_id in enumerate(partition):
                 clusters[cluster_id].append(i)
 
+            squared_distances = condensed_distances**2
             for cluster in clusters.values():
                 if len(cluster) > 1:
                     scores = confidences(cluster, squared_distances, N)


### PR DESCRIPTION
Addresses https://github.com/dedupeio/dedupe/issues/911 and possibly related to https://github.com/dedupeio/dedupe/pull/880.

Pre-computing squared distances avoids it being recomputed in a loop each time `confidences` is called. This saves a lot of time when the loop has a large number of iterations and condensed distances is large.