### PR TITLE
add in-memory option

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -61,13 +61,17 @@ class Matching(object):
     Base Class for Record Matching Classes
     """
 
-    def __init__(self, num_cores: Optional[int], **kwargs) -> None:
+    def __init__(self, 
+                 num_cores: Optional[int],
+                 in_memory: bool = False,
+                 **kwargs) -> None:
 
         if num_cores is None:
             self.num_cores = multiprocessing.cpu_count()
         else:
             self.num_cores = num_cores
 
+        self.in_memory = in_memory
         self._fingerprinter: Optional[blocking.Fingerprinter] = None
         self.data_model: datamodel.DataModel
         self.classifier: Classifier
@@ -128,8 +132,7 @@ class DedupeMatching(IntegralMatching):
 
     def partition(self,
                   data: Data,
-                  threshold: float = 0.5,
-                  in_memory: bool = False) -> Clusters:  # pragma: no cover
+                  threshold: float = 0.5) -> Clusters:  # pragma: no cover
         """
         Identifies records that all refer to the same entity, returns
         tuples containing a sequence of record ids and corresponding
@@ -157,9 +160,6 @@ class DedupeMatching(IntegralMatching):
 
                        Lowering the number will increase recall,
                        raising it will increase precision
-                    
-            in_memory: Boolean that if True will compute pairs using
-                       sqlite in RAM rather than writing to disk.
 
         .. code:: python
 
@@ -170,7 +170,7 @@ class DedupeMatching(IntegralMatching):
             ((10, 11), (0.899, 0.899))]
 
         """
-        pairs = self.pairs(data, in_memory=in_memory)
+        pairs = self.pairs(data)
         pair_scores = self.score(pairs)
         clusters = self.cluster(pair_scores, threshold)
 
@@ -198,7 +198,7 @@ class DedupeMatching(IntegralMatching):
         for singleton in singletons:
             yield (singleton, ), (1.0, )
 
-    def pairs(self, data, in_memory):
+    def pairs(self, data):
         '''
         Yield pairs of records that share common fingerprints.
 
@@ -211,8 +211,6 @@ class DedupeMatching(IntegralMatching):
             data: Dictionary of records, where the keys are record_ids
                   and the values are dictionaries with the keys being
                   field names
-            in_memory: Boolean that if True will compute pairs using
-                       sqlite in RAM rather than writing to disk.
 
         .. code:: python
 
@@ -233,7 +231,7 @@ class DedupeMatching(IntegralMatching):
         # Blocking and pair generation are typically the first memory
         # bottlenecks, so we'll use sqlite3 to avoid doing them in memory
         with tempfile.TemporaryDirectory() as temp_dir:
-            if in_memory:
+            if self.in_memory:
                 con = sqlite3.connect(':memory:')
             else:
                 con = sqlite3.connect(temp_dir + '/blocks.db')
@@ -341,7 +339,7 @@ class RecordLinkMatching(IntegralMatching):
     Use RecordLinkMatching when you have two datasets that you want to merge
     """
 
-    def pairs(self, data_1: Data, data_2: Data, in_memory=False) -> RecordPairs:
+    def pairs(self, data_1: Data, data_2: Data) -> RecordPairs:
         """
         Yield pairs of records that share common fingerprints.
 
@@ -357,8 +355,6 @@ class RecordLinkMatching(IntegralMatching):
                     with the keys being field names
             data_2: Dictionary of records from second dataset, same
                     form as data_1
-            in_memory: Boolean that if True will compute pairs using
-                       sqlite in RAM rather than writing to disk.
 
         .. code:: python
 
@@ -379,7 +375,7 @@ class RecordLinkMatching(IntegralMatching):
         # Blocking and pair generation are typically the first memory
         # bottlenecks, so we'll use sqlite3 to avoid doing them in memory
         with tempfile.TemporaryDirectory() as temp_dir:
-            if in_memory:
+            if self.in_memory:
                 con = sqlite3.connect(':memory:')
             else:
                 con = sqlite3.connect(temp_dir + '/blocks.db')
@@ -425,8 +421,7 @@ class RecordLinkMatching(IntegralMatching):
              data_1: Data,
              data_2: Data,
              threshold: float = 0.5,
-             constraint: JoinConstraint = "one-to-one",
-             in_memory: bool = False) -> Links:
+             constraint: JoinConstraint = "one-to-one") -> Links:
         """
         Identifies pairs of records that refer to the same entity.
 
@@ -481,9 +476,6 @@ class RecordLinkMatching(IntegralMatching):
                               multiple records in data_2 and vice
                               versa. This is like a SQL inner join.
 
-            in_memory: Boolean that if True will compute pairs using
-                       sqlite in RAM rather than writing to disk.
-
         .. code:: python
 
            > links = matcher.join(data_1, data_2, threshold=0.5)
@@ -500,7 +492,7 @@ class RecordLinkMatching(IntegralMatching):
             '%s is an invalid constraint option. Valid options include '
             'one-to-one, many-to-one, or many-to-many' % constraint)
 
-        pairs = self.pairs(data_1, data_2, in_memory=in_memory)
+        pairs = self.pairs(data_1, data_2)
         pair_scores = self.score(pairs)
 
         if constraint == 'one-to-one':
@@ -637,12 +629,11 @@ class GazetteerMatching(Matching):
 
     def __init__(self, 
                  num_cores: Optional[int],
-                 in_memory: Optional[bool],
                  **kwargs) -> None:
 
         super().__init__(num_cores, **kwargs)
 
-        if in_memory:
+        if self.in_memory:
             self.db = ':memory:'
         else:
           self.temp_dir = tempfile.TemporaryDirectory()

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -629,9 +629,10 @@ class GazetteerMatching(Matching):
 
     def __init__(self,
                  num_cores: Optional[int],
+                 in_memory: bool = False,
                  **kwargs) -> None:
 
-        super().__init__(num_cores, **kwargs)
+        super().__init__(num_cores, in_memory, **kwargs)
 
         if self.in_memory:
             self.db = ':memory:'

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -61,7 +61,7 @@ class Matching(object):
     Base Class for Record Matching Classes
     """
 
-    def __init__(self, 
+    def __init__(self,
                  num_cores: Optional[int],
                  in_memory: bool = False,
                  **kwargs) -> None:
@@ -627,7 +627,7 @@ class RecordLinkMatching(IntegralMatching):
 
 class GazetteerMatching(Matching):
 
-    def __init__(self, 
+    def __init__(self,
                  num_cores: Optional[int],
                  **kwargs) -> None:
 
@@ -636,8 +636,8 @@ class GazetteerMatching(Matching):
         if self.in_memory:
             self.db = ':memory:'
         else:
-          self.temp_dir = tempfile.TemporaryDirectory()
-          self.db = self.temp_dir.name + '/blocks.db'
+            self.temp_dir = tempfile.TemporaryDirectory()
+            self.db = self.temp_dir.name + '/blocks.db'
 
         self.indexed_data: Dict[RecordID, RecordDict] = {}
 

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -929,6 +929,7 @@ class StaticMatching(Matching):
     def __init__(self,
                  settings_file: BinaryIO,
                  num_cores: Optional[int] = None,
+                 in_memory: bool = False,
                  **kwargs) -> None:  # pragma: no cover
         """
         Args:
@@ -940,6 +941,11 @@ class StaticMatching(Matching):
                        available on the machine. If set to 0, then
                        multiprocessing will be disabled.
 
+            in_memory: Boolean that if True will compute pairs using
+                       sqlite in RAM with the sqlite3 ':memory:' option
+                       rather than writing to disk. May be faster if
+                       sufficient memory is available.
+
         .. warning::
 
             If using multiprocessing on Windows or Mac OS X, then
@@ -948,7 +954,7 @@ class StaticMatching(Matching):
             https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
 
         """
-        super().__init__(num_cores, **kwargs)
+        super().__init__(num_cores, in_memory, **kwargs)
 
         try:
             self.data_model = pickle.load(settings_file)
@@ -980,6 +986,7 @@ class ActiveMatching(Matching):
     def __init__(self,
                  variable_definition: Sequence[Mapping],
                  num_cores: Optional[int] = None,
+                 in_memory: bool = False,
                  **kwargs) -> None:
         """
         Args:
@@ -992,6 +999,11 @@ class ActiveMatching(Matching):
                        available on the machine. If set to 0, then
                        multiprocessing will be disabled.
 
+            in_memory: Boolean that if True will compute pairs using
+                       sqlite in RAM with the sqlite3 ':memory:' option
+                       rather than writing to disk. May be faster if
+                       sufficient memory is available.
+
         .. warning::
 
             If using multiprocessing on Windows or Mac OS X, then
@@ -1000,7 +1012,7 @@ class ActiveMatching(Matching):
             https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
 
         """
-        super().__init__(num_cores, **kwargs)
+        super().__init__(num_cores, in_memory, **kwargs)
 
         self.data_model = datamodel.DataModel(variable_definition)
 


### PR DESCRIPTION
Using sqlite for join operations is good when memory is an issue, but has a performance hit when it is not. Depending on the input data, parameterization of the model, and machine running the code it may be preferable to run in memory or use sqlite to push things to disk. I'm working with a large dataset, but on a machine with plenty of RAM.

Conveniently sqlite3 gives the option to run in memory simply by changing the connection string to `:memory:`. See [here](https://docs.python.org/3/library/sqlite3.html). In my particular case changing the connection from a temporary file to working in memory reduces compute time of partition from 91 minutes to 24 minutes.

I propose adding an `in_memory` option that defaults to False (maintaining existing behavior) but gives the option to run things in memory. Thanks to the sqlite3 option, it comes with very little additional complexity.

If you are interested in this change maybe it makes sense to add test cases, but I'm not sure where they belong exactly. I've tried running tests/canonical_matching.py and  tests/canonical.py with in_memory hard coded to True and False to verify that much works.