### PR TITLE
Make use of "Index" and "Canopy" in docs consistent

### DIFF
--- a/docs/Making-smart-comparisons.rst
+++ b/docs/Making-smart-comparisons.rst
@@ -70,7 +70,7 @@ very few comparisons and still have confidence that will compare records
 that truly are duplicates.
 
 This task is called blocking, and we approach it in two ways: predicate
-blocks and canopies.
+blocks and index blocks.
 
 Predicate blocks
 ~~~~~~~~~~~~~~~~
@@ -123,6 +123,8 @@ Others simple predicates Dedupe uses include:
 * near integers 
 * common four gram 
 * common six gram
+
+.. _index-blocks-label:
 
 Index Blocks
 ~~~~~~~~~~~~

--- a/docs/Variable-definition.rst
+++ b/docs/Variable-definition.rst
@@ -40,7 +40,7 @@ ShortString Types
 ^^^^^^^^^^^^^^^^^
 
 A ``ShortString`` type field is just like ``String`` types except that dedupe
-will not try to learn a canopy blocking rule for these fields, which can
+will not try to learn an :ref:`index-block-label` rule for these fields, which can
 speed up the training phase considerably.
 
 Zip codes and city names are good candidates for this type. If in doubt,


### PR DESCRIPTION
I don't really understand the difference between Index
and Canopy blocks (Index blocks are a type of blocks,
and canopy clustering is an algorithm to implement them?),
but I was getting a bit confused from reading the docs as to
the difference between them, and how they relate to the
`index_predicates` argument to the `train()` meethods.

So, this is my best guess as to how to make their use in
the docs more consistent. I would be happy to improve
this if you point me in the right direction of what to read
up on.