### PR TITLE
Add Docs build to CI

### DIFF
--- a/docs/API-documentation.rst
+++ b/docs/API-documentation.rst
@@ -136,6 +136,7 @@ Dedupe and StaticDedupe
 .. currentmodule:: dedupe
 
 .. class:: Dedupe
+   :noindex:
 
     .. attribute:: fingerprinter
     
@@ -147,6 +148,7 @@ Dedupe and StaticDedupe
     .. automethod:: cluster
 
 .. class:: StaticDedupe
+   :noindex:
 
     .. attribute:: fingerprinter
     
@@ -169,6 +171,7 @@ RecordLink and StaticRecordLink
 *******************************
 
 .. class:: RecordLink
+   :noindex:
 
     .. attribute:: fingerprinter
     
@@ -181,6 +184,7 @@ RecordLink and StaticRecordLink
     .. automethod:: many_to_one		    
 
 .. class:: StaticRecordLink
+   :noindex:
 
    .. attribute:: fingerprinter
     
@@ -207,6 +211,7 @@ Gazetteer and StaticGazetteer
 *****************************
 
 .. class:: Gazetteer
+   :noindex:
 
     .. attribute:: fingerprinter
     
@@ -218,6 +223,7 @@ Gazetteer and StaticGazetteer
     .. automethod:: many_to_n
 
 .. class:: StaticGazeteer
+   :noindex:
 
     .. attribute:: fingerprinter
     
@@ -240,8 +246,7 @@ Gazetteer and StaticGazetteer
 .. autoclass:: dedupe.blocking.Fingerprinter
 
    .. automethod:: __call__
-   .. autoinstanceattribute:: index_fields
-       :annotation:
+   .. autoattribute:: index_fields
    .. automethod:: index
    .. automethod:: unindex	       
    .. automethod:: reset_indices

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/Variable-definition.rst
+++ b/docs/Variable-definition.rst
@@ -42,7 +42,7 @@ ShortString Types
 ^^^^^^^^^^^^^^^^^
 
 A ``ShortString`` type field is just like ``String`` types except that dedupe
-will not try to learn an :ref:`index-block-label` rule for these fields, which can
+will not try to learn any :ref:`index blocking rules <index-blocks-label>` for these fields, which can
 speed up the training phase considerably.
 
 Zip codes and city names are good candidates for this type. If in doubt,


### PR DESCRIPTION
There was a bug in that last PR that was merged, such that a reference didn't work. This could have gotten caught in CI, so this adds building the docs to the CI run.

This also fixes up some warnings and errors that previously existed but were slipping through. You can see the logs of the failed docs builds by looking at the Github Action runs for each of the commits in  https://github.com/NickCrews/dedupe/commits/docs-CI

IDK exactly how the docs are built in prod (I assume its readthedocs?) but you could also solve this problem using the readthedocs GitHub integration (https://docs.readthedocs.io/en/stable/integrations.html), so that RTD actually does the build and you get a more "true" preview of the final product.