### PR TITLE
Restore casting of int in randomPairs

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -57,7 +57,7 @@ def randomPairs(n_records: int, sample_size: int) -> IndicesIterator:
     else:
         try:
             random_pairs = numpy.array(random.sample(range(n), sample_size),
-                                       dtype=numpy.uint)
+                                       dtype=numpy.int)
         except OverflowError:
             return randomPairsWithReplacement(n_records, sample_size)
 

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -57,16 +57,17 @@ def randomPairs(n_records: int, sample_size: int) -> IndicesIterator:
     else:
         try:
             random_pairs = numpy.array(random.sample(range(n), sample_size),
-                                       dtype=numpy.int)
+                                       dtype=numpy.uint)
         except OverflowError:
             return randomPairsWithReplacement(n_records, sample_size)
 
     b: int = 1 - 2 * n_records
 
     i = (-b - 2 * numpy.sqrt(2 * (n - random_pairs) + 0.25)) // 2
-    i = i.astype(int)
+    i = i.astype(numpy.uint)
 
     j = random_pairs + i * (b + i + 2) // 2 + 1
+    j = j.astype(numpy.uint)
 
     return zip(i, j)
 

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -56,7 +56,8 @@ def randomPairs(n_records: int, sample_size: int) -> IndicesIterator:
         random_pairs = numpy.arange(n)
     else:
         try:
-            random_pairs = numpy.array(random.sample(range(n), sample_size))
+            random_pairs = numpy.array(random.sample(range(n), sample_size),
+                                       dtype=numpy.uint)
         except OverflowError:
             return randomPairsWithReplacement(n_records, sample_size)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,8 +23,8 @@ class RandomPairsTest(unittest.TestCase):
 
         random.seed(123)
         numpy.random.seed(123)
-        target = [(2489768049, 2967327842)]
-        assert list(dedupe.core.randomPairs(10**10, 1)) == target
+        target = [(3624216819017203053, 5278339153051796802)]
+        assert list(dedupe.core.randomPairs(10**20, 1)) == target
 
     def test_random_pair_match(self):
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,7 @@ class RandomPairsTest(unittest.TestCase):
 
         random.seed(123)
         numpy.random.seed(123)
-        if numpy.iinfo(numpy.uint).max == 2147483647:
+        if numpy.iinfo(numpy.int).max == 2147483647:
             target = [(843828734, 914636141)]
         else:
             target = [(3624216819017203053, 5278339153051796802)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,10 @@ class RandomPairsTest(unittest.TestCase):
 
         random.seed(123)
         numpy.random.seed(123)
-        target = [(3624216819017203053, 5278339153051796802)]
+        if numpy.iinfo(numpy.uint).max == 2147483647:
+            target = [(843828734, 914636141)]
+        else:
+            target = [(3624216819017203053, 5278339153051796802)]
         assert list(dedupe.core.randomPairs(10**20, 1)) == target
 
     def test_random_pair_match(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,10 @@ class RandomPairsTest(unittest.TestCase):
         random_pairs = list(dedupe.core.randomPairs(10**4, 1))
         assert random_pairs == target
 
-        assert list(dedupe.core.randomPairs(10**10, 1))
+        random.seed(123)
+        numpy.random.seed(123)
+        target = [(2489768049, 2967327842)]
+        assert list(dedupe.core.randomPairs(10**10, 1)) == target
 
     def test_random_pair_match(self):
 


### PR DESCRIPTION
random.sample(range(n), sample_size) can produce integers of basically infinite size. if that size is bigger than numpy.uint64 then numpy.array(random.sample(range(n), sample_size)) does not throw an overflow, but uses the dtype of "object"

we want to make sure the dtype is an unsigned int to catch overflow problems early.

this will close #945 

