### PR TITLE
Fix docs CSS (weird formatting on docs #968)

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -108,38 +108,6 @@ h4:before, h4:before, h6:before {
     pointer-events: none;
 }
 
-/* Padding for method/class permalinks, which require more finesse */
-/* (Use fake padding instead of an invisible ::before pseudo-element) */
-.rst-content dl:not(.docutils) dt,
-.rst-content dl:not(.docutils) dl dt,
-.rst-content dl:not(.docutils) dt:first-child {
-    padding-top: 55px;
-    margin-top: -55px;
-    background: none;
-    border-top: none;
-    border-left: none;
-    margin-bottom: 10px;
-}
-
-/* Use ::before pseudo-elements to style the method/class permalinks */
-.rst-content dl:not(.docutils) dt:before,
-.rst-content dl:not(.docutils) dl dt:before {
-    display: block;
-    content: " ";
-    margin-bottom: -23px;
-    height: 28px;
-    background: #e7f2fa;
-    border-top: solid 3px #6ab0de;
-}
-
-/* Methods should be grey */
-.rst-content dl:not(.docutils) dl dt:before {
-    background: #f0f0f0;
-    border-top: none;
-    border-left: solid 3px #ccc;
-    margin-left: -5px;
-}
-
 /* =================== */
 /* RTD theme overrides */
 /* =================== */


### PR DESCRIPTION
Fixes https://github.com/dedupeio/dedupe/issues/968.

Don't really know what this custom CSS was trying to do, but it looks better now, hopefully it didn't make something else look worse that I didn't find.

But, I'm of the opinion that all else equal, less CSS is better

Before:
<img width="673" alt="image" src="https://user-images.githubusercontent.com/10820686/155026678-12518eb3-63bc-4148-976b-451574b25907.png">

After:
<img width="679" alt="image" src="https://user-images.githubusercontent.com/10820686/155026700-d1a45f0b-a837-492b-b8fc-7800fa56e8d2.png">

Before:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/10820686/155026771-3aae7538-f54e-4d97-928e-e9636a11d7da.png">

After:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/10820686/155026798-3f602c0b-e51a-49ae-a6c3-cbaed0c408e7.png">


