### PR TITLE
Fixup broken on-demand benchmarks

### DIFF
--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -78,5 +78,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '\nBenchmarks completed. View runner logs here: ' + run_url + '\nRegex used: '+ 'regex "' + ENV_VARS["REGEX"] + '"\n' + ENV_VARS["BENCH_OUTPUT"]
+              body: '\nBenchmarks completed. View runner logs here: ' + run_url + '\nRegex used: "' + ENV_VARS["REGEX"] + '"\n' + ENV_VARS["BENCH_OUTPUT"]
             })

--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install .
 
       - name: Run benchmarks
         id: bench

--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -12,8 +12,7 @@ env:
 jobs:
   benchmarks:
     name: "Run benchmarks"
-    # TODO: Support more benchmarking options later, against different branches, against self, etc
-    if: startsWith(github.event.comment.body, '@github-actions benchmark')
+    if: startsWith(github.event.comment.body, '@benchmark')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -50,12 +49,17 @@ jobs:
         run: |
           # extracting the regex, see https://stackoverflow.com/a/36798723
           REGEX=$(echo "$COMMENT" | sed -n "s/^.*-b\s*\(\S*\).*$/\1/p")
+          if [ -z "$REGEX" ]; then
+            BENCHMARKS=""
+          else
+            BENCHMARKS="--benchmarks $REGEX"
+          fi
           cd benchmarks
           asv check -E existing
           git remote add upstream https://github.com/dedupeio/dedupe.git
           git fetch upstream
           asv machine --yes
-          asv continuous -f 1.1 -b $REGEX upstream/main HEAD
+          asv continuous -f 1.1 $BENCHMARKS upstream/main HEAD
           echo 'BENCH_OUTPUT<<EOF' >> $GITHUB_ENV
           asv compare -f 1.1 upstream/main HEAD >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
@@ -74,5 +78,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '\nBenchmarks completed. View runner logs here.' + run_url + '\nRegex used: '+ 'regex ' + ENV_VARS["REGEX"] + '\n' + ENV_VARS["BENCH_OUTPUT"]
+              body: '\nBenchmarks completed. View runner logs here: ' + run_url + '\nRegex used: '+ 'regex ' + ENV_VARS["REGEX"] + '\n' + ENV_VARS["BENCH_OUTPUT"]
             })

--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true # This is a fake failure, asv will exit code 1 for regressions
         run: |
           # extracting the regex, see https://stackoverflow.com/a/36798723
-          REGEX=$(echo "$COMMENT" | sed -n "s/^.*-b\s*\(\S*\).*$/\1/p")
+          REGEX=$(echo "$COMMENT" | sed -n "s/^@benchmark\s\+-b\s*\(\S*\).*$/\1/p")
           if [ -z "$REGEX" ]; then
             BENCHMARKS=""
           else

--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -52,7 +52,7 @@ jobs:
           if [ -z "$REGEX" ]; then
             BENCHMARKS=""
           else
-            BENCHMARKS="--benchmarks $REGEX"
+            BENCHMARKS="-b $REGEX"
           fi
           cd benchmarks
           asv check -E existing

--- a/.github/workflows/benchmark-bot.yml
+++ b/.github/workflows/benchmark-bot.yml
@@ -78,5 +78,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '\nBenchmarks completed. View runner logs here: ' + run_url + '\nRegex used: '+ 'regex ' + ENV_VARS["REGEX"] + '\n' + ENV_VARS["BENCH_OUTPUT"]
+              body: '\nBenchmarks completed. View runner logs here: ' + run_url + '\nRegex used: '+ 'regex "' + ENV_VARS["REGEX"] + '"\n' + ENV_VARS["BENCH_OUTPUT"]
             })


### PR DESCRIPTION
- changes the summoning command
- if no matching regex (eg just `@benchmark`) then run all

closes #1015