### PR TITLE
Datamodel-refactor

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,6 +7,7 @@ jobs:
     timeout-minutes: 40
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]

--- a/benchmarks/benchmarks/canonical.py
+++ b/benchmarks/benchmarks/canonical.py
@@ -34,7 +34,7 @@ class Canonical:
                 deduper = dedupe.StaticDedupe(f)
 
         else:
-            fields = [
+            variables = [
                 {"field": "name", "type": "String"},
                 {"field": "name", "type": "Exact"},
                 {"field": "address", "type": "String"},
@@ -42,7 +42,7 @@ class Canonical:
                 {"field": "city", "type": "ShortString"},
             ]
 
-            deduper = dedupe.Dedupe(fields, num_cores=5)
+            deduper = dedupe.Dedupe(variables, num_cores=5)
             deduper.prepare_training(self.data, sample_size=10000)
             deduper.mark_pairs(self.training_pairs)
             deduper.train(index_predicates=True)

--- a/benchmarks/benchmarks/canonical_gazetteer.py
+++ b/benchmarks/benchmarks/canonical_gazetteer.py
@@ -5,6 +5,7 @@ import dedupe
 
 from benchmarks import canonical_matching
 from benchmarks import common
+from dedupe import variables
 
 
 def make_report(data, clustering):
@@ -32,14 +33,14 @@ class Gazetteer(canonical_matching.Matching):
             with open(self.settings_file, "rb") as f:
                 gazetteer = dedupe.StaticGazetteer(f)
         else:
-            fields = [
+            variables = [
                 {"field": "name", "type": "String"},
                 {"field": "address", "type": "String"},
                 {"field": "cuisine", "type": "String"},
                 {"field": "city", "type": "String"},
             ]
 
-            gazetteer = dedupe.Gazetteer(fields)
+            gazetteer = dedupe.Gazetteer(variables)
             gazetteer.prepare_training(data_1, data_2, sample_size=10000)
             gazetteer.mark_pairs(self.training_pairs)
             gazetteer.train()

--- a/benchmarks/benchmarks/canonical_matching.py
+++ b/benchmarks/benchmarks/canonical_matching.py
@@ -46,13 +46,13 @@ class Matching:
             with open(self.settings_file, "rb") as f:
                 deduper = dedupe.StaticRecordLink(f)
         else:
-            fields = [
+            variables = [
                 {"field": "name", "type": "String"},
                 {"field": "address", "type": "String"},
                 {"field": "cuisine", "type": "String"},
                 {"field": "city", "type": "String"},
             ]
-            deduper = dedupe.RecordLink(fields)
+            deduper = dedupe.RecordLink(variables)
             deduper.prepare_training(data_1, data_2, sample_size=10000)
             deduper.mark_pairs(self.training_pairs)
             deduper.train()

--- a/dedupe/_typing.py
+++ b/dedupe/_typing.py
@@ -24,6 +24,12 @@ LookupResults = Iterable[Tuple[RecordID, Tuple[Tuple[RecordID, float], ...]]]
 JoinConstraint = Literal["one-to-one", "many-to-one", "many-to-many"]
 
 
+class VariableDefinition(TypedDict, total=False):
+    field: str
+    type: str
+    # Others also allowed
+
+
 class TrainingData(TypedDict):
     match: List[TrainingExample]
     distinct: List[TrainingExample]

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -27,7 +27,6 @@ import dedupe.labeler as labeler
 import dedupe.predicates
 
 from typing import (
-    Mapping,
     Optional,
     List,
     Tuple,
@@ -55,6 +54,7 @@ from dedupe._typing import (
     TrainingData,
     Classifier,
     JoinConstraint,
+    VariableDefinition,
 )
 
 logger = logging.getLogger(__name__)
@@ -1050,7 +1050,7 @@ class ActiveMatching(Matching):
 
     def __init__(
         self,
-        variable_definition: Sequence[Mapping],
+        variable_definition: Sequence[VariableDefinition],
         num_cores: Optional[int] = None,
         in_memory: bool = False,
         **kwargs

--- a/dedupe/blocking.py
+++ b/dedupe/blocking.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from collections import defaultdict
 import logging
 import time
 
-from typing import Generator, Tuple, Iterable, Dict, List, Union
+from typing import Generator, Iterable, Union
 from dedupe._typing import Record, RecordID, Data
 
 import dedupe.predicates
@@ -22,11 +23,11 @@ def index_list():
 class Fingerprinter(object):
     """Takes in a record and returns all blocks that record belongs to"""
 
-    def __init__(self, predicates: List[dedupe.predicates.Predicate]) -> None:
+    def __init__(self, predicates: list[dedupe.predicates.Predicate]) -> None:
 
         self.predicates = predicates
 
-        self.index_fields: Dict[str, Dict[str, List[dedupe.predicates.IndexPredicate]]]
+        self.index_fields: dict[str, dict[str, list[dedupe.predicates.IndexPredicate]]]
         self.index_fields = defaultdict(index_list)
         """
         A dictionary of all the fingerprinter methods that use an
@@ -44,7 +45,7 @@ class Fingerprinter(object):
 
     def __call__(
         self, records: Iterable[Record], target: bool = False
-    ) -> Generator[Tuple[str, RecordID], None, None]:
+    ) -> Generator[tuple[str, RecordID], None, None]:
         """
         Generate the predicates for records. Yields tuples of (predicate,
         record_id).

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -1,16 +1,17 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import itertools
 from collections import defaultdict
 import array
 import logging
 import tempfile
+from typing import Iterable, cast, Generator, Sequence
 
 import numpy
 import scipy.cluster.hierarchy
 
-from typing import Iterable, Dict, cast, List, Set, Generator, Sequence, Tuple
 from dedupe._typing import Clusters, RecordID, Links
 
 logger = logging.getLogger(__name__)
@@ -101,7 +102,7 @@ def _connected_components(
 
 def union_find(scored_pairs: numpy.ndarray) -> numpy.ndarray:
 
-    root: Dict[RecordID, int] = {}
+    root: dict[RecordID, int] = {}
 
     components = {}
 
@@ -178,7 +179,7 @@ def union_find(scored_pairs: numpy.ndarray) -> numpy.ndarray:
 
 def condensedDistance(
     dupes: numpy.ndarray,
-) -> Tuple[Dict[int, RecordID], numpy.ndarray, int]:
+) -> tuple[dict[int, RecordID], numpy.ndarray, int]:
     """
     Convert the pairwise list of distances in dupes to "condensed
     distance matrix" required by the hierarchical clustering
@@ -245,7 +246,7 @@ def cluster(
                 linkage, distance_threshold, criterion="distance"
             )
 
-            clusters: Dict[int, List[int]] = defaultdict(list)
+            clusters: dict[int, list[int]] = defaultdict(list)
 
             for i, cluster_id in enumerate(partition):
                 clusters[cluster_id].append(i)
@@ -286,8 +287,8 @@ def confidences(
 
 
 def greedyMatching(dupes: numpy.ndarray) -> Links:
-    A: Set[RecordID] = set()
-    B: Set[RecordID] = set()
+    A: set[RecordID] = set()
+    B: set[RecordID] = set()
 
     dupes.sort(order="score")
     dupes = dupes[::-1]

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import collections
 import itertools
 import sys
-from typing import List, Tuple, Dict, Set, Iterator
+from typing import Tuple, Iterator
 import random
 import warnings
 
@@ -136,8 +137,8 @@ def console_label(deduper: dedupe.api.ActiveMatching) -> None:  # pragma: no cov
     fields = unique(var.field for var in deduper.data_model.primary_variables)
 
     buffer_len = 1  # Max number of previous operations
-    unlabeled: List[TrainingExample] = []
-    labeled: List[LabeledPair] = []
+    unlabeled: list[TrainingExample] = []
+    labeled: list[LabeledPair] = []
 
     while not finished:
         if use_previous:
@@ -226,10 +227,10 @@ def training_data_link(
          then they are distinct records.
     """
 
-    identified_records: Dict[str, Tuple[List[RecordID], List[RecordID]]]
+    identified_records: dict[str, tuple[list[RecordID], list[RecordID]]]
     identified_records = collections.defaultdict(lambda: ([], []))
-    matched_pairs: Set[Tuple[RecordID, RecordID]] = set()
-    distinct_pairs: Set[Tuple[RecordID, RecordID]] = set()
+    matched_pairs: set[tuple[RecordID, RecordID]] = set()
+    distinct_pairs: set[tuple[RecordID, RecordID]] = set()
 
     for record_id, record in data_1.items():
         identified_records[record[common_key]][0].append(record_id)
@@ -285,11 +286,11 @@ def training_data_dedupe(
          then they are distinct records.
     """
 
-    identified_records: Dict[str, List[RecordID]]
+    identified_records: dict[str, list[RecordID]]
     identified_records = collections.defaultdict(list)
-    matched_pairs: Set[Tuple[RecordID, RecordID]] = set()
-    distinct_pairs: Set[Tuple[RecordID, RecordID]] = set()
-    unique_record_ids: Set[RecordID] = set()
+    matched_pairs: set[tuple[RecordID, RecordID]] = set()
+    distinct_pairs: set[tuple[RecordID, RecordID]] = set()
+    unique_record_ids: set[RecordID] = set()
 
     # a list of record_ids associated with each common_key
     for record_id, record in data.items():
@@ -321,7 +322,7 @@ def training_data_dedupe(
     return training_pairs
 
 
-def canonicalize(record_cluster: List[RecordDict]) -> RecordDict:  # pragma: nocover
+def canonicalize(record_cluster: list[RecordDict]) -> RecordDict:  # pragma: nocover
     """
     Constructs a canonical representation of a duplicate cluster by
     finding canonical values for each field

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -133,7 +133,7 @@ def console_label(deduper: dedupe.api.ActiveMatching) -> None:  # pragma: no cov
 
     finished = False
     use_previous = False
-    fields = unique(field.field for field in deduper.data_model.primary_fields)
+    fields = unique(var.field for var in deduper.data_model.primary_variables)
 
     buffer_len = 1  # Max number of previous operations
     unlabeled: List[TrainingExample] = []

--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import itertools
 import tempfile
@@ -11,7 +12,6 @@ import multiprocessing.dummy
 import queue
 from typing import (
     Iterator,
-    Tuple,
     Mapping,
     Sequence,
     Union,
@@ -251,7 +251,7 @@ def appropriate_imap(num_cores):
     return imap, pool
 
 
-def peek(seq: Iterator) -> Tuple[Optional[Any], Iterator]:
+def peek(seq: Iterator) -> tuple[Optional[Any], Iterator]:
     try:
         first = next(seq)
     except TypeError as e:
@@ -285,21 +285,21 @@ def Enumerator(start: int = 0, initial: tuple = ()) -> collections.defaultdict:
 
 
 @overload
-def sniff_id_type(ids: Sequence[Tuple[int, int]]) -> Type[int]:
+def sniff_id_type(ids: Sequence[tuple[int, int]]) -> Type[int]:
     ...
 
 
 @overload
-def sniff_id_type(ids: Sequence[Tuple[str, str]]) -> Tuple[Type[str], int]:
+def sniff_id_type(ids: Sequence[tuple[str, str]]) -> tuple[Type[str], int]:
     ...
 
 
 def sniff_id_type(
-    ids: Sequence[Tuple[RecordID, RecordID]]
-) -> Union[Type[int], Tuple[Type[str], int]]:
+    ids: Sequence[tuple[RecordID, RecordID]]
+) -> Union[Type[int], tuple[Type[str], int]]:
     example = ids[0][0]
     python_type = type(example)
-    dtype: Union[Type[int], Tuple[Type[str], int]]
+    dtype: Union[Type[int], tuple[Type[str], int]]
     if python_type is bytes or python_type is str:
         dtype = (str, 256)
     elif python_type is int:

--- a/dedupe/datamodel.py
+++ b/dedupe/datamodel.py
@@ -14,8 +14,7 @@ for _, module, _ in pkgutil.iter_modules(  # type: ignore
 ):
     __import__(module)
 
-
-FIELD_CLASSES = {k: v for k, v in base.allSubclasses(base.FieldType) if k}
+FIELD_CLASSES = {k: v for k, v in base.FieldType.all_subclasses() if k}
 
 
 class DataModel(object):

--- a/dedupe/datamodel.py
+++ b/dedupe/datamodel.py
@@ -1,41 +1,46 @@
 import pkgutil
+from typing import Container, Iterable
 
 import numpy
 import copyreg
 import types
 
 import dedupe.variables
-import dedupe.variables.base as base
-from dedupe.variables.base import MissingDataType
+from dedupe.variables.base import (
+    FieldType as FieldVariable,
+    MissingDataType,
+    Variable,
+)
 from dedupe.variables.interaction import InteractionType
+from dedupe._typing import VariableDefinition
 
 for _, module, _ in pkgutil.iter_modules(  # type: ignore
     dedupe.variables.__path__, "dedupe.variables."
 ):
     __import__(module)
 
-FIELD_CLASSES = {k: v for k, v in base.FieldType.all_subclasses() if k}
+VARIABLE_CLASSES = {k: v for k, v in FieldVariable.all_subclasses() if k}
 
 
 class DataModel(object):
-    def __init__(self, fields):
+    def __init__(self, variable_definitions: Iterable[VariableDefinition]):
+        variable_definitions = list(variable_definitions)
+        if not variable_definitions:
+            raise ValueError("The variable definitions cannot be empty")
+        all_variables: list[Variable]
+        self.primary_variables, all_variables = typify_variables(variable_definitions)
+        self._derived_start = len(all_variables)
 
-        if not fields:
-            raise ValueError("The field definitions cannot be empty")
-        primary_fields, variables = typifyFields(fields)
-        self.primary_fields = primary_fields
-        self._derived_start = len(variables)
+        all_variables += interactions(variable_definitions, self.primary_variables)
+        all_variables += missing(all_variables)
 
-        variables += interactions(fields, primary_fields)
-        variables += missing(variables)
+        self._missing_field_indices = missing_field_indices(all_variables)
+        self._interaction_indices = interaction_indices(all_variables)
 
-        self._missing_field_indices = missing_field_indices(variables)
-        self._interaction_indices = interaction_indices(variables)
-
-        self._variables = variables
+        self._len = len(all_variables)
 
     def __len__(self):
-        return len(self._variables)
+        return self._len
 
     # Changing this from a property to just a normal attribute causes
     # pickling problems, because we are removing static methods from
@@ -45,18 +50,15 @@ class DataModel(object):
     def _field_comparators(self):
         start = 0
         stop = 0
-        comparators = []
-        for field in self.primary_fields:
-            stop = start + len(field)
-            comparators.append((field.field, field.comparator, start, stop))
+        for var in self.primary_variables:
+            stop = start + len(var)
+            yield (var.field, var.comparator, start, stop)
             start = stop
 
-        return comparators
-
-    def predicates(self, index_predicates=True, canopies=True):
+    def predicates(self, index_predicates=True, canopies=True) -> set:
         predicates = set()
-        for definition in self.primary_fields:
-            for predicate in definition.predicates:
+        for var in self.primary_variables:
+            for predicate in var.predicates:
                 if hasattr(predicate, "index"):
                     if index_predicates:
                         if hasattr(predicate, "canopy"):
@@ -70,15 +72,14 @@ class DataModel(object):
 
         return predicates
 
-    def distances(self, record_pairs):
+    def distances(self, record_pairs) -> numpy.ndarray:
         num_records = len(record_pairs)
 
         distances = numpy.empty((num_records, len(self)), "f4")
-        field_comparators = self._field_comparators
 
         for i, (record_1, record_2) in enumerate(record_pairs):
 
-            for field, compare, start, stop in field_comparators:
+            for field, compare, start, stop in self._field_comparators:
                 if record_1[field] is not None and record_2[field] is not None:
                     distances[i, start:stop] = compare(record_1[field], record_2[field])
                 elif hasattr(compare, "missing"):
@@ -86,34 +87,30 @@ class DataModel(object):
                 else:
                     distances[i, start:stop] = numpy.nan
 
-        distances = self._derivedDistances(distances)
+        distances = self._add_derived_distances(distances)
 
         return distances
 
-    def _derivedDistances(self, primary_distances):
-        distances = primary_distances
-
+    def _add_derived_distances(self, distances: numpy.ndarray) -> numpy.ndarray:
         current_column = self._derived_start
 
-        for interaction in self._interaction_indices:
-            distances[:, current_column] = numpy.prod(distances[:, interaction], axis=1)
-
+        for indices in self._interaction_indices:
+            distances[:, current_column] = numpy.prod(distances[:, indices], axis=1)
             current_column += 1
 
-        missing_data = numpy.isnan(distances[:, :current_column])
+        is_missing = numpy.isnan(distances[:, :current_column])
 
-        distances[:, :current_column][missing_data] = 0
+        distances[:, :current_column][is_missing] = 0
 
         if self._missing_field_indices:
             distances[:, current_column:] = (
-                1 - missing_data[:, self._missing_field_indices]
+                1 - is_missing[:, self._missing_field_indices]
             )
 
         return distances
 
-    def check(self, record):
-        for field_comparator in self._field_comparators:
-            field = field_comparator[0]
+    def check(self, record: Container) -> None:
+        for field, _, _, _ in self._field_comparators:
             if field not in record:
                 raise ValueError(
                     "Records do not line up with data model. "
@@ -122,108 +119,103 @@ class DataModel(object):
                 )
 
 
-def typifyFields(fields):
-    primary_fields = []
-    data_model = []
+def typify_variables(
+    variable_definitions: Iterable[VariableDefinition],
+) -> tuple[list[FieldVariable], list[Variable]]:
+    primary_variables = []
+    all_variables = []
     only_custom = True
 
-    for definition in fields:
+    for definition in variable_definitions:
         try:
-            field_type = definition["type"]
+            variable_type = definition["type"]
         except TypeError:
             raise TypeError(
-                "Incorrect field specification: field "
+                "Incorrect variable specification: variable "
                 "specifications are dictionaries that must "
                 "include a type definition, ex. "
                 "{'field' : 'Phone', type: 'String'}"
             )
         except KeyError:
             raise KeyError(
-                "Missing field type: fields "
+                "Missing variable type: variable "
                 "specifications are dictionaries that must "
                 "include a type definition, ex. "
                 "{'field' : 'Phone', type: 'String'}"
             )
 
-        if field_type != "Custom":
+        if variable_type != "Custom":
             only_custom = False
 
-        if field_type == "Interaction":
+        if variable_type == "Interaction":
             continue
 
-        if field_type == "FuzzyCategorical" and "other fields" not in definition:
-            definition["other fields"] = [
+        if variable_type == "FuzzyCategorical" and "other fields" not in definition:
+            definition["other fields"] = [  # type: ignore
                 d["field"]
-                for d in fields
+                for d in variable_definitions
                 if ("field" in d and d["field"] != definition["field"])
             ]
 
         try:
-            field_class = FIELD_CLASSES[field_type]
+            variable_class = VARIABLE_CLASSES[variable_type]
         except KeyError:
             raise KeyError(
                 "Field type %s not valid. Valid types include %s"
-                % (definition["type"], ", ".join(FIELD_CLASSES))
+                % (definition["type"], ", ".join(VARIABLE_CLASSES))
             )
 
-        field_object = field_class(definition)
-        primary_fields.append(field_object)
+        variable_object = variable_class(definition)
+        primary_variables.append(variable_object)
 
-        if hasattr(field_object, "higher_vars"):
-            data_model.extend(field_object.higher_vars)
+        if hasattr(variable_object, "higher_vars"):
+            all_variables.extend(variable_object.higher_vars)  # type: ignore
         else:
-            data_model.append(field_object)
+            all_variables.append(variable_object)
 
     if only_custom:
         raise ValueError(
-            "At least one of the field types needs to be a type"
+            "At least one of the variable types needs to be a type"
             "other than 'Custom'. 'Custom' types have no associated"
             "blocking rules"
         )
 
-    return primary_fields, data_model
+    return primary_variables, all_variables
 
 
-def missing(data_model):
+def missing(variables: list[Variable]) -> list[MissingDataType]:
     missing_variables = []
-    for definition in data_model[:]:
-        if definition.has_missing:
-            missing_variables.append(MissingDataType(definition.name))
-
+    for var in variables:
+        if var.has_missing:
+            missing_variables.append(MissingDataType(var.name))
     return missing_variables
 
 
-def interactions(definitions, primary_fields):
-    field_d = {field.name: field for field in primary_fields}
-    interaction_class = InteractionType
+def interactions(
+    definitions: Iterable[VariableDefinition], primary_variables: list[FieldVariable]
+) -> list[InteractionType]:
+    field_d = {field.name: field for field in primary_variables}
 
     interactions = []
-
     for definition in definitions:
         if definition["type"] == "Interaction":
-            field = interaction_class(definition)
-            field.expandInteractions(field_d)
-            interactions.extend(field.higher_vars)
-
+            var = InteractionType(definition)
+            var.expandInteractions(field_d)
+            interactions.extend(var.higher_vars)
     return interactions
 
 
-def missing_field_indices(variables):
-    return [i for i, definition in enumerate(variables) if definition.has_missing]
+def missing_field_indices(variables: list[Variable]) -> list[int]:
+    return [i for i, var in enumerate(variables) if var.has_missing]
 
 
-def interaction_indices(variables):
+def interaction_indices(variables: list[Variable]) -> list[list[int]]:
+    var_names = [var.name for var in variables]
     indices = []
-
-    field_names = [field.name for field in variables]
-
-    for definition in variables:
-        if hasattr(definition, "interaction_fields"):
-            interaction_indices = []
-            for interaction_field in definition.interaction_fields:
-                interaction_indices.append(field_names.index(interaction_field))
+    for var in variables:
+        if hasattr(var, "interaction_fields"):
+            interaction_indices = [var_names.index(f) for f in var.interaction_fields]  # type: ignore
             indices.append(interaction_indices)
-
     return indices
 
 

--- a/dedupe/datamodel.py
+++ b/dedupe/datamodel.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import pkgutil
 from typing import Container, Iterable
-
-import numpy
 import copyreg
 import types
+
+import numpy
 
 import dedupe.variables
 from dedupe.variables.base import (

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import random
 from abc import ABC, abstractmethod
 import logging
 
 import numpy
-from typing import List
 from typing_extensions import Protocol
 import sklearn.linear_model
 
@@ -42,10 +43,10 @@ class RLRLearner(sklearn.linear_model.LogisticRegression, ActiveLearner):
     def __init__(self, data_model):
         super().__init__()
         self.data_model = data_model
-        self._candidates: List[TrainingExample]
+        self._candidates: list[TrainingExample]
 
     @property
-    def candidates(self) -> List[TrainingExample]:
+    def candidates(self) -> list[TrainingExample]:
         return self._candidates
 
     @candidates.setter
@@ -306,7 +307,7 @@ class DisagreementLearner(ActiveLearner):
 
     classifier: RLRLearner
     blocker: BlockLearner
-    candidates: List[TrainingExample]
+    candidates: list[TrainingExample]
 
     def _common_init(self):
 

--- a/dedupe/predicates.py
+++ b/dedupe/predicates.py
@@ -1,18 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import re
 import math
 import itertools
 import string
 import abc
+from typing import Sequence, Callable, Any
 
 from doublemetaphone import doublemetaphone
+
 from dedupe.cpredicates import ngrams, initials
 import dedupe.tfidf as tfidf
 import dedupe.levenshtein as levenshtein
-
-from typing import Sequence, Callable, Any, Tuple, Set
 from dedupe._typing import RecordDict
 
 words = re.compile(r"[\w']+").findall
@@ -75,12 +76,12 @@ class Predicate(abc.ABC):
 class SimplePredicate(Predicate):
     type = "SimplePredicate"
 
-    def __init__(self, func: Callable[[Any], Tuple[str, ...]], field: str):
+    def __init__(self, func: Callable[[Any], tuple[str, ...]], field: str):
         self.func = func
         self.__name__ = "(%s, %s)" % (func.__name__, field)
         self.field = field
 
-    def __call__(self, record: RecordDict, **kwargs) -> Tuple[str, ...]:
+    def __call__(self, record: RecordDict, **kwargs) -> tuple[str, ...]:
         column = record[self.field]
         if column:
             return self.func(column)
@@ -348,7 +349,7 @@ class CompoundPredicate(tuple, Predicate):
             raise ValueError("Can only combine predicates")
 
 
-def wholeFieldPredicate(field: Any) -> Tuple[str]:
+def wholeFieldPredicate(field: Any) -> tuple[str]:
     """return the whole field"""
     return (str(field),)
 
@@ -374,16 +375,16 @@ def firstTwoTokensPredicate(field: str) -> Sequence[str]:
         return ()
 
 
-def commonIntegerPredicate(field: str) -> Set[str]:
+def commonIntegerPredicate(field: str) -> set[str]:
     """return any integers"""
     return {str(int(i)) for i in integers(field)}
 
 
-def alphaNumericPredicate(field: str) -> Set[str]:
+def alphaNumericPredicate(field: str) -> set[str]:
     return set(alpha_numeric(field))
 
 
-def nearIntegersPredicate(field: str) -> Set[str]:
+def nearIntegersPredicate(field: str) -> set[str]:
     """return any integers N, N+1, and N-1"""
     ints = integers(field)
     near_ints = set()
@@ -396,11 +397,11 @@ def nearIntegersPredicate(field: str) -> Set[str]:
     return near_ints
 
 
-def hundredIntegerPredicate(field: str) -> Set[str]:
+def hundredIntegerPredicate(field: str) -> set[str]:
     return {str(int(i))[:-2] + "00" for i in integers(field)}
 
 
-def hundredIntegersOddPredicate(field: str) -> Set[str]:
+def hundredIntegersOddPredicate(field: str) -> set[str]:
     return {str(int(i))[:-2] + "0" + str(int(i) % 2) for i in integers(field)}
 
 
@@ -412,7 +413,7 @@ def firstIntegerPredicate(field: str) -> Sequence[str]:
         return ()
 
 
-def ngramsTokens(field: Sequence[Any], n: int) -> Set[str]:
+def ngramsTokens(field: Sequence[Any], n: int) -> set[str]:
     grams = set()
     n_tokens = len(field)
     for i in range(n_tokens):
@@ -421,23 +422,23 @@ def ngramsTokens(field: Sequence[Any], n: int) -> Set[str]:
     return grams
 
 
-def commonTwoTokens(field: str) -> Set[str]:
+def commonTwoTokens(field: str) -> set[str]:
     return ngramsTokens(field.split(), 2)
 
 
-def commonThreeTokens(field: str) -> Set[str]:
+def commonThreeTokens(field: str) -> set[str]:
     return ngramsTokens(field.split(), 3)
 
 
-def fingerprint(field: str) -> Tuple[str]:
+def fingerprint(field: str) -> tuple[str]:
     return ("".join(sorted(field.split())).strip(),)
 
 
-def oneGramFingerprint(field: str) -> Tuple[str]:
+def oneGramFingerprint(field: str) -> tuple[str]:
     return ("".join(sorted(set(ngrams(field.replace(" ", ""), 1)))).strip(),)
 
 
-def twoGramFingerprint(field: str) -> Tuple[str, ...]:
+def twoGramFingerprint(field: str) -> tuple[str, ...]:
     if len(field) > 1:
         return (
             "".join(
@@ -448,27 +449,27 @@ def twoGramFingerprint(field: str) -> Tuple[str, ...]:
         return ()
 
 
-def commonFourGram(field: str) -> Set[str]:
+def commonFourGram(field: str) -> set[str]:
     """return 4-grams"""
     return set(ngrams(field.replace(" ", ""), 4))
 
 
-def commonSixGram(field: str) -> Set[str]:
+def commonSixGram(field: str) -> set[str]:
     """return 6-grams"""
     return set(ngrams(field.replace(" ", ""), 6))
 
 
-def sameThreeCharStartPredicate(field: str) -> Tuple[str]:
+def sameThreeCharStartPredicate(field: str) -> tuple[str]:
     """return first three characters"""
     return initials(field.replace(" ", ""), 3)
 
 
-def sameFiveCharStartPredicate(field: str) -> Tuple[str]:
+def sameFiveCharStartPredicate(field: str) -> tuple[str]:
     """return first five characters"""
     return initials(field.replace(" ", ""), 5)
 
 
-def sameSevenCharStartPredicate(field: str) -> Tuple[str]:
+def sameSevenCharStartPredicate(field: str) -> tuple[str]:
     """return first seven characters"""
     return initials(field.replace(" ", ""), 7)
 
@@ -480,7 +481,7 @@ def suffixArray(field):
             yield field[i:]
 
 
-def sortedAcronym(field: str) -> Tuple[str]:
+def sortedAcronym(field: str) -> tuple[str]:
     return ("".join(sorted(each[0] for each in field.split())),)
 
 

--- a/dedupe/tfidf.py
+++ b/dedupe/tfidf.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from .canopy_index import CanopyIndex
-from .index import Index
-from .core import Enumerator
+from dedupe.canopy_index import CanopyIndex
+from dedupe.index import Index
+from dedupe.core import Enumerator
 
 logger = logging.getLogger(__name__)
 

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # provides functions for selecting a sample of training data
+from __future__ import annotations
 
 import itertools
 import logging
@@ -11,7 +12,7 @@ import random
 from abc import ABC
 import math
 
-from typing import Dict, Sequence, Iterable, Tuple, List, Union, FrozenSet, Optional
+from typing import Dict, Sequence, Iterable, FrozenSet
 
 from . import blocking
 from .predicates import Predicate
@@ -75,7 +76,7 @@ class BlockLearner(ABC):
         return candidates
 
     def random_forest_candidates(
-        self, match_cover: Cover, comparison_cover: Cover, K: Optional[int] = None
+        self, match_cover: Cover, comparison_cover: Cover, K: int | None = None
     ) -> Cover:
         predicates = list(match_cover)
         matches = list(frozenset.union(*match_cover.values()))
@@ -96,7 +97,7 @@ class BlockLearner(ABC):
             # the base for the constructing k-conjunctions
             candidate = None
             covered_comparisons = InfiniteSet()
-            covered_matches: Union[FrozenSet[int], InfiniteSet] = InfiniteSet()
+            covered_matches: frozenset[int] | InfiniteSet = InfiniteSet()
             covered_sample_matches = InfiniteSet()
 
             def score(predicate: Predicate) -> float:
@@ -227,11 +228,11 @@ class BranchBound(object):
 
         self.cheapest_score: float = float("inf")
         self.original_cover: Cover = {}
-        self.cheapest: Tuple[Predicate, ...] = ()
+        self.cheapest: tuple[Predicate, ...] = ()
 
     def search(
-        self, candidates: Cover, partial: Tuple[Predicate, ...] = ()
-    ) -> Tuple[Predicate, ...]:
+        self, candidates: Cover, partial: tuple[Predicate, ...] = ()
+    ) -> tuple[Predicate, ...]:
         if self.calls <= 0:
             return self.cheapest
 
@@ -283,14 +284,14 @@ class BranchBound(object):
         return self.cheapest
 
     @staticmethod
-    def order_by(candidates: Cover, p: Predicate) -> Tuple[int, float]:
+    def order_by(candidates: Cover, p: Predicate) -> tuple[int, float]:
         return (len(candidates[p]), -p.count)  # type: ignore
 
     @staticmethod
     def score(partial: Iterable[Predicate]) -> float:
         return sum(p.count for p in partial)  # type: ignore
 
-    def covered(self, partial: Tuple[Predicate, ...]) -> int:
+    def covered(self, partial: tuple[Predicate, ...]) -> int:
         if partial:
             return len(frozenset.union(*(self.original_cover[p] for p in partial)))
         else:
@@ -343,7 +344,7 @@ class Resampler(object):
         c = collections.Counter(sampled)
         max_value = len(sequence) + 1
 
-        self.replacements: Dict[int, List[int]] = {}
+        self.replacements: dict[int, list[int]] = {}
         for k, v in c.items():
             self.replacements[k] = [v]
             if v > 1:

--- a/dedupe/variables/base.py
+++ b/dedupe/variables/base.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import Callable, Sequence, Type, Any, Iterable
+from typing import Callable, ClassVar, Sequence, Type, Any, Iterable
 
 from dedupe import predicates
 
 
 class Variable(object):
     name: str
-    type: str
-    predicates: Sequence[Callable[[Any], Any]]
+    type: ClassVar[str]
+    predicates: list[Callable[[Any], Any]]
 
     def __len__(self):
         return 1

--- a/dedupe/variables/base.py
+++ b/dedupe/variables/base.py
@@ -4,6 +4,10 @@ from dedupe import predicates
 
 
 class Variable(object):
+    name: str
+    type: str
+    predicates: Sequence[Callable[[Any], Any]]
+
     def __len__(self):
         return 1
 
@@ -33,6 +37,13 @@ class Variable(object):
         odict["predicates"] = None
 
         return odict
+
+    @classmethod
+    def all_subclasses(cls):
+        for q in cls.__subclasses__():
+            yield getattr(q, "type", None), q
+            for p in q.all_subclasses():
+                yield p
 
 
 class DerivedType(Variable):
@@ -99,13 +110,6 @@ class CustomType(FieldType):
                 self.type,
                 self.comparator.__name__,
             )
-
-
-def allSubclasses(cls):
-    for q in cls.__subclasses__():
-        yield q.type, q
-        for p in allSubclasses(q):
-            yield p
 
 
 def indexPredicates(predicates, thresholds, field):

--- a/dedupe/variables/base.py
+++ b/dedupe/variables/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Sequence, Type, Any, Iterable
 
 from dedupe import predicates
@@ -69,6 +71,7 @@ class FieldType(Variable):
     _index_predicates: Sequence[Type[predicates.IndexPredicate]] = []
     _predicate_functions: Sequence[Callable[[Any], Iterable[str]]] = ()
     _Predicate = predicates.SimplePredicate
+    comparator: Callable[[Any, Any], int | float]
 
     def __init__(self, definition):
         self.field = definition["field"]

--- a/dedupe/variables/categorical_type.py
+++ b/dedupe/variables/categorical_type.py
@@ -1,4 +1,4 @@
-from .base import FieldType, DerivedType
+from dedupe.variables.base import FieldType, DerivedType
 from dedupe import predicates
 from categorical import CategoricalComparator
 

--- a/dedupe/variables/exact.py
+++ b/dedupe/variables/exact.py
@@ -1,4 +1,4 @@
-from .base import FieldType
+from dedupe.variables.base import FieldType
 from dedupe import predicates
 
 

--- a/dedupe/variables/exists.py
+++ b/dedupe/variables/exists.py
@@ -1,13 +1,16 @@
-from .base import DerivedType
-from categorical import CategoricalComparator
-from .categorical_type import CategoricalType
+from __future__ import annotations
 
-from typing import List, Callable
+from typing import Callable
+
+from categorical import CategoricalComparator
+
+from dedupe.variables.base import DerivedType
+from dedupe.variables.categorical_type import CategoricalType
 
 
 class ExistsType(CategoricalType):
     type = "Exists"
-    _predicate_functions: List[Callable] = []
+    _predicate_functions: list[Callable] = []
 
     def __init__(self, definition):
 

--- a/dedupe/variables/interaction.py
+++ b/dedupe/variables/interaction.py
@@ -1,5 +1,6 @@
-from .base import Variable
 import itertools
+
+from dedupe.variables.base import Variable
 
 
 class InteractionType(Variable):

--- a/dedupe/variables/latlong.py
+++ b/dedupe/variables/latlong.py
@@ -1,8 +1,9 @@
 from math import sqrt
 
-from .base import FieldType
-from dedupe import predicates
 from haversine import haversine
+
+from dedupe import predicates
+from dedupe.variables.base import FieldType
 
 
 class LatLongType(FieldType):

--- a/dedupe/variables/price.py
+++ b/dedupe/variables/price.py
@@ -1,6 +1,7 @@
 import numpy
+
 from dedupe import predicates
-from .base import FieldType
+from dedupe.variables.base import FieldType
 
 
 class PriceType(FieldType):

--- a/dedupe/variables/set.py
+++ b/dedupe/variables/set.py
@@ -1,6 +1,7 @@
-from .base import FieldType
-from dedupe import predicates
 from simplecosine.cosine import CosineSetSimilarity
+
+from dedupe import predicates
+from dedupe.variables.base import FieldType
 
 
 class SetType(FieldType):

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -5,8 +5,6 @@ from affinegap import normalizedAffineGapDistance as affineGap
 from highered import CRFEditDistance
 from simplecosine.cosine import CosineTextSimilarity
 
-from typing import Optional
-
 crfEd = CRFEditDistance()
 
 base_predicates = (
@@ -32,7 +30,6 @@ base_predicates = (
 
 
 class BaseStringType(FieldType):
-    type: Optional[str] = None
     _Predicate = predicates.StringPredicate
 
     def __init__(self, definition):

--- a/dedupe/variables/string.py
+++ b/dedupe/variables/string.py
@@ -1,9 +1,9 @@
-from .base import FieldType, indexPredicates
-from dedupe import predicates
-
 from affinegap import normalizedAffineGapDistance as affineGap
 from highered import CRFEditDistance
 from simplecosine.cosine import CosineTextSimilarity
+
+from dedupe.variables.base import FieldType, indexPredicates
+from dedupe import predicates
 
 crfEd = CRFEditDistance()
 


### PR DESCRIPTION
@fgregg ready for a review whenever, thanks! I can split into smaller PRs if easier, but I think individual commits are manageable if you review those one at a time.

This is a refactor, no real change besides the one in `Move all_subclasses() to classmethod`.

- add type hints
- use new type hint notation
- the biggest thing is updating variable name usage in datamodel.py to be consistent with docs usage. Keeping field vs variable vs "variable definition" all consistent.
- couple of other small tweaks in the internals of datamodel, eg using generators to be a little cleaner, making __len__ calculated more cleanly, removing a few temp variables.
- don't fail-fast on tests