### PR TITLE
tighten predicate typing

### DIFF
--- a/dedupe/variables/base.py
+++ b/dedupe/variables/base.py
@@ -8,7 +8,7 @@ from dedupe import predicates
 class Variable(object):
     name: str
     type: ClassVar[str]
-    predicates: list[Callable[[Any], Any]]
+    predicates: list[Callable[[Any], Iterable[str]]]
 
     def __len__(self):
         return 1


### PR DESCRIPTION
a predicate should always return an iterable of strings 