### PR TITLE
Remove buggy pyproject.toml from manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include dedupe/cpredicates.pyx
-pyproject.toml


### PR DESCRIPTION
with `pip -v install -e .` I was getting warnings
that it didn't know what do do with this line.
Should be `include pyproject.toml`
But we don't even need it with setuptools 43+
per https://packaging.python.org/en/latest/guides/using-manifest-in/