### PR TITLE
Update numpy requirement to >=1.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "affinegap>=1.3",
     "categorical-distance>=1.9",
     "dedupe-variable-datetime",
-    "numpy>=1.13",
+    "numpy>=1.20",
     "doublemetaphone",
     "highered>=0.2.0",
     "simplecosine>=1.2",


### PR DESCRIPTION
numpy >= 1.20 is required after #1040 added an import for numpy.typing, which was added in 1.20.