### PR TITLE
udpate readme for cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Once you have virtualenvwrapper set up,
 
 ```bash
 mkvirtualenv dedupe
-git clone git://github.com/dedupeio/dedupe.git
+git clone https://github.com/dedupeio/dedupe.git
 cd dedupe
 pip install -e . --config-settings editable_mode=compat
 pip install -r requirements.txt


### PR DESCRIPTION
Small thing, but it may save some others some time. I think 

```bash
git clone git://github.com/dedupeio/dedupe.git
```
should be 

```bash
git clone https://github.com/dedupeio/dedupe.git
```

At least I got a time out error because of this I believe: https://github.blog/2021-09-01-improving-git-protocol-security-github/

Thought was fastest to directly fix it.