### PR TITLE
Unmap file to prevent PermissionError when deleting temp file on Win

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1479,6 +1479,7 @@ def _cleanup_scores(arr: Scores) -> None:
     except AttributeError:
         pass
     else:
+        arr._mmap.close()  # Unmap file to prevent PermissionError when deleting temp file
         del arr
         if mmap_file:
             os.remove(mmap_file)


### PR DESCRIPTION
On Windows, a PermissionError is raised when trying to removing the temporary file:
`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: ...`

Unmap the temp file before deleting it prevents this error.