### PR TITLE
Reference plugin variables using "module:class" strings

### DIFF
--- a/dedupe/datamodel.py
+++ b/dedupe/datamodel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copyreg
 import pkgutil
 import types
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Type, cast
 
 import numpy
 
@@ -142,6 +142,16 @@ class DataModel(object):
         self.__dict__ = d
 
 
+def _get_variable_class(variable_type: str) -> Type[Variable]:
+    try:
+        return VARIABLE_CLASSES[variable_type]
+    except KeyError:
+        raise KeyError(
+            "Field type %s not valid. Valid types include %s"
+            % (variable_type, ", ".join(VARIABLE_CLASSES))
+        )
+
+
 def typify_variables(
     variable_definitions: Iterable[VariableDefinition],
 ) -> tuple[list[FieldVariable], list[Variable]]:
@@ -180,14 +190,7 @@ def typify_variables(
                 if ("field" in d and d["field"] != definition["field"])
             ]
 
-        try:
-            variable_class = VARIABLE_CLASSES[variable_type]
-        except KeyError:
-            raise KeyError(
-                "Field type %s not valid. Valid types include %s"
-                % (definition["type"], ", ".join(VARIABLE_CLASSES))
-            )
-
+        variable_class = _get_variable_class(variable_type)
         variable_object = variable_class(definition)
         assert isinstance(variable_object, FieldVariable)
 

--- a/dedupe/variables/__init__.py
+++ b/dedupe/variables/__init__.py
@@ -1,3 +1,35 @@
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
+
+from dedupe.variables.base import CustomType as Custom
+
+# flake8: noqa
+from dedupe.variables.categorical_type import CategoricalType as Categorical
+from dedupe.variables.date_time import DateTimeType as DateTime
+from dedupe.variables.exact import ExactType as Exact
+from dedupe.variables.exists import ExistsType as Exists
+from dedupe.variables.interaction import InteractionType as Interaction
+from dedupe.variables.latlong import LatLongType as LatLong
+from dedupe.variables.price import PriceType as Price
+from dedupe.variables.set import SetType as Set
+from dedupe.variables.string import ShortStringType as ShortString
+from dedupe.variables.string import StringType as String
+from dedupe.variables.string import TextType as Text
+
+__all__ = sorted(
+    [
+        "Custom",
+        "Categorical",
+        "DateTime",
+        "Exact",
+        "Exists",
+        "Interaction",
+        "LatLong",
+        "Price",
+        "Set",
+        "ShortString",
+        "String",
+        "Text",
+    ]
+)

--- a/dedupe/variables/base.py
+++ b/dedupe/variables/base.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from dedupe import predicates
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, Generator, Iterable, Optional, Sequence, Type
+    from typing import Any, ClassVar, Iterable, Sequence, Type
 
     from dedupe._typing import Comparator, PredicateFunction, VariableDefinition
 
@@ -46,15 +46,6 @@ class Variable(object):
         odict["predicates"] = None
 
         return odict
-
-    @classmethod
-    def all_subclasses(
-        cls,
-    ) -> Generator[tuple[Optional[str], Type["Variable"]], None, None]:
-        for q in cls.__subclasses__():
-            yield getattr(q, "type", None), q
-            for p in q.all_subclasses():
-                yield p
 
 
 class DerivedType(Variable):

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -6,6 +6,7 @@ import unittest
 import numpy
 
 import dedupe
+from dedupe.datamodel import DataModel
 
 DATA = {
     100: {"name": "Bob", "age": "50"},
@@ -31,8 +32,6 @@ DATA_SAMPLE = (
 
 class DataModelTest(unittest.TestCase):
     def test_data_model(self):
-        DataModel = dedupe.datamodel.DataModel
-
         self.assertRaises(TypeError, DataModel)
 
         data_model = DataModel(

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -74,6 +74,33 @@ class DataModelTest(unittest.TestCase):
 
         assert data_model._missing_field_indices == []
 
+    def test_builtin_variables_basic(self):
+        """Tests that we can instantiate a DataModel with all of the
+        builtin variable types
+        """
+        builtin_types = [
+            "Exists",
+            "Exact",
+            "LatLong",
+            "Price",
+            "Set",
+            "ShortString",
+            "String",
+            "Text",
+            "DateTime",
+        ]
+        defs = [
+            {
+                "field": "a",
+                "variable name": "a",
+                "type": t,
+            }
+            for t in builtin_types
+        ]
+        defs.append({"type": "Categorical", "field": "a", "categories": ["foo", "bar"]})
+        defs.append({"type": "Custom", "field": "a", "comparator": lambda x, y: 0})
+        DataModel(defs)
+
 
 class ConnectedComponentsTest(unittest.TestCase):
     def test_components(self):


### PR DESCRIPTION
Will close https://github.com/dedupeio/dedupe/issues/1085

This probably could do with some more polishing, eg removing `type` from every Variable class, and swapping `if variable_type == "Interaction"` to parsing the variable type, then checking`if isinstance(variable_type, dedupe.variables.InteractionType)`