### PR TITLE
purify id types

### DIFF
--- a/dedupe/_typing.py
+++ b/dedupe/_typing.py
@@ -33,38 +33,52 @@ if TYPE_CHECKING:
 RecordDict = Mapping[str, Any]
 RecordID = Union[int, str]
 RecordIDDType = Union[Type[int], Tuple[Type[str], Literal[256]]]
-RecordIDPair = Tuple[RecordID, RecordID]
-Record = Tuple[RecordID, RecordDict]
-RecordPair = Tuple[Record, Record]
-RecordPairs = Iterator[RecordPair]
-Block = List[RecordPair]
-Blocks = Iterator[Block]
-Cluster = Tuple[
-    Tuple[RecordID, ...], Union[numpy.typing.NDArray[numpy.float_], Tuple[float, ...]]
+RecordIDPair = Union[Tuple[int, int], Tuple[str, str]]
+RecordInt = Tuple[int, RecordDict]
+RecordStr = Tuple[str, RecordDict]
+Record = Union[RecordInt, RecordStr]
+RecordPairInt = Tuple[RecordInt, RecordInt]
+RecordPairStr = Tuple[RecordStr, RecordStr]
+RecordPairs = Union[Iterator[RecordPairInt], Iterator[RecordPairStr]]
+BlockInt = List[RecordPairInt]
+BlockStr = List[RecordPairStr]
+Block = Union[RecordPairInt, RecordPairStr]
+BlocksInt = Iterator[BlockInt]
+BlocksStr = Iterator[BlockStr]
+Blocks = Union[BlocksInt, BlocksStr]
+ClusterInt = Tuple[
+    Tuple[int, ...], Union[numpy.typing.NDArray[numpy.float_], Tuple[float, ...]]
 ]
-Clusters = Iterable[Cluster]
+ClusterStr = Tuple[
+    Tuple[str, ...], Union[numpy.typing.NDArray[numpy.float_], Tuple[float, ...]]
+]
+ClustersInt = Iterable[ClusterInt]
+ClustersStr = Iterable[ClusterStr]
+Clusters = Union[ClustersInt, ClustersStr]
 
-# this is not quite right. we are saying that Data is a dictionary that
-# could have mixed string or integer keys, but really Data needs to be either
-# a dictionary with only string keys, or a dictionary with only integer keys.
-#
-# we might be able to express that instead with a lot of overloads, but i'm
-# not sure it's worth it.
-Data = Mapping[RecordID, RecordDict]
+DataInt = Mapping[int, RecordDict]
+DataStr = Mapping[str, RecordDict]
+Data = Union[DataInt, DataStr]
 
 RecordDictPair = Tuple[RecordDict, RecordDict]
 RecordDictPairs = List[RecordDictPair]
 ArrayLinks = Iterable[numpy.ndarray]
-TupleLinks = Iterable[Tuple[Tuple[RecordID, RecordID], float]]
+TupleLinksInt = Iterable[Tuple[Tuple[int, int], float]]
+TupleLinksStr = Iterable[Tuple[Tuple[str, str], float]]
+TupleLinks = Union[TupleLinksInt, TupleLinksStr]
 Links = Union[ArrayLinks, TupleLinks]
-LookupResults = Iterable[Tuple[RecordID, Tuple[Tuple[RecordID, float], ...]]]
+LookupResultsInt = Iterable[Tuple[int, Tuple[Tuple[int, float], ...]]]
+LookupResultsStr = Iterable[Tuple[str, Tuple[Tuple[str, float], ...]]]
+LookupResults = Union[LookupResultsInt, LookupResultsStr]
 JoinConstraint = Literal["one-to-one", "many-to-one", "many-to-many"]
 Comparator = Callable[[Any, Any], Union[Union[int, float], Sequence[Union[int, float]]]]
 Scores = Union[numpy.memmap, numpy.ndarray]
 Labels = List[Literal[0, 1]]
 LabelsLike = Iterable[Literal[0, 1]]
 Cover = Dict["Predicate", FrozenSet[int]]
-ComparisonCover = Dict["Predicate", FrozenSet[Tuple[RecordID, RecordID]]]
+ComparisonCoverInt = Dict["Predicate", FrozenSet[Tuple[int, int]]]
+ComparisonCoverStr = Dict["Predicate", FrozenSet[Tuple[str, str]]]
+ComparisonCover = Union[ComparisonCoverInt, ComparisonCoverStr]
 PredicateFunction = Callable[[Any], Iterable[str]]
 
 VariableDefinition = TypedDict(

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -14,7 +14,7 @@ import pickle
 import sqlite3
 import tempfile
 import warnings
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast, overload
 
 import numpy
 import sklearn.linear_model
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
         MutableMapping,
         TextIO,
         Union,
-        overload,
     )
 
     import numpy.typing

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -679,7 +679,7 @@ class GazetteerMatching(Matching):
         self.indexed_data: Union[
             MutableMapping[int, RecordDict], MutableMapping[str, RecordDict]
         ]
-        self.indexed_data = {}
+        self.indexed_data = {}  # type: ignore[assignment]
 
     def _close(self) -> None:
         if not self.in_memory:

--- a/dedupe/canonical.py
+++ b/dedupe/canonical.py
@@ -28,7 +28,7 @@ def getCentroid(attribute_variants: Sequence[str], comparator: Comparator) -> st
 
     # there can be ties for minimum, average distance string
     min_dist_indices: numpy.typing.NDArray[numpy.int_]
-    min_dist_indices = numpy.where(average_distance == average_distance.min())[0]  # type: ignore
+    min_dist_indices = numpy.where(average_distance == average_distance.min())[0]
 
     if len(min_dist_indices) > 1:
         centroid = breakCentroidTie(attribute_variants, min_dist_indices)

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -7,13 +7,14 @@ import itertools
 import random
 import sys
 import warnings
-from typing import Iterator, Tuple
+from typing import Iterator, Tuple, overload
 
 import numpy
 
 import dedupe
 from dedupe._typing import (
-    Data,
+    DataInt,
+    DataStr,
     Literal,
     RecordDict,
     RecordDictPair,
@@ -203,8 +204,22 @@ def console_label(deduper: dedupe.api.ActiveMatching) -> None:  # pragma: no cov
         _mark_pair(deduper, labeled_pair)
 
 
+@overload
 def training_data_link(
-    data_1: Data, data_2: Data, common_key: str, training_size: int = 50000
+    data_1: DataInt, data_2: DataInt, common_key: str, training_size: int = 50000
+) -> TrainingData:  # pragma: nocover
+    ...
+
+
+@overload
+def training_data_link(
+    data_1: DataStr, data_2: DataStr, common_key: str, training_size: int = 50000
+) -> TrainingData:  # pragma: nocover
+    ...
+
+
+def training_data_link(
+    data_1, data_2, common_key, training_size=50000
 ) -> TrainingData:  # pragma: nocover
     """
     Construct training data for consumption by the func:`mark_pairs`
@@ -265,8 +280,22 @@ def training_data_link(
     return training_pairs
 
 
+@overload
 def training_data_dedupe(
-    data: Data, common_key: str, training_size: int = 50000
+    data: DataInt, common_key: str, training_size: int = 50000
+) -> TrainingData:  # pragma: nocover
+    ...
+
+
+@overload
+def training_data_dedupe(
+    data: DataStr, common_key: str, training_size: int = 50000
+) -> TrainingData:  # pragma: nocover
+    ...
+
+
+def training_data_dedupe(
+    data, common_key, training_size=50000
 ) -> TrainingData:  # pragma: nocover
     """
     Construct training data for consumption by the func:`mark_pairs`

--- a/dedupe/datamodel.py
+++ b/dedupe/datamodel.py
@@ -240,12 +240,12 @@ def interaction_indices(variables: list[Variable]) -> list[list[int]]:
     indices = []
     for var in variables:
         if hasattr(var, "interaction_fields"):
-            interaction_indices = [var_names.index(f) for f in var.interaction_fields]  # type: ignore
+            interaction_indices = [var_names.index(f) for f in var.interaction_fields]
             indices.append(interaction_indices)
     return indices
 
 
-def reduce_method(m):  # type: ignore[no-untyped-def]
+def reduce_method(m):
     return (getattr, (m.__self__, m.__func__.__name__))
 
 

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import numpy
 import numpy.typing
@@ -13,7 +13,7 @@ import dedupe.core as core
 import dedupe.training as training
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, Literal, Mapping, overload
+    from typing import Dict, Iterable, Literal, Mapping
 
     from dedupe._typing import (
         Data,

--- a/dedupe/labeler.py
+++ b/dedupe/labeler.py
@@ -13,9 +13,16 @@ import dedupe.core as core
 import dedupe.training as training
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, Literal, Mapping
+    from typing import Dict, Iterable, Literal, Mapping, overload
 
-    from dedupe._typing import Data, FeaturizerFunction, Labels, LabelsLike
+    from dedupe._typing import (
+        Data,
+        DataInt,
+        DataStr,
+        FeaturizerFunction,
+        Labels,
+        LabelsLike,
+    )
     from dedupe._typing import RecordDictPair as TrainingExample
     from dedupe._typing import RecordDictPairs as TrainingExamples
     from dedupe._typing import RecordIDPair
@@ -245,7 +252,15 @@ class DedupeBlockLearner(BlockLearner):
         for pred in blocker.index_predicates:
             pred.freeze(records)
 
-    def _sample(self, data: Data, sample_size: int) -> TrainingExamples:
+    @overload
+    def _sample(self, data: DataInt, sample_size: int) -> TrainingExamples:
+        ...
+
+    @overload
+    def _sample(self, data: DataStr, sample_size: int) -> TrainingExamples:
+        ...
+
+    def _sample(self, data, sample_size):
 
         sample_indices = self._sample_indices(
             sample_size, len(data) * (len(data) - 1) // 2
@@ -302,7 +317,19 @@ class RecordLinkBlockLearner(BlockLearner):
         for pred in blocker.index_predicates:
             pred.freeze(A, B)
 
-    def _sample(self, data_1: Data, data_2: Data, sample_size: int) -> TrainingExamples:
+    @overload
+    def _sample(
+        self, data_1: DataInt, data_2: DataInt, sample_size: int
+    ) -> TrainingExamples:
+        ...
+
+    @overload
+    def _sample(
+        self, data_1: DataStr, data_2: DataStr, sample_size: int
+    ) -> TrainingExamples:
+        ...
+
+    def _sample(self, data_1, data_2, sample_size):
 
         sample_indices = self._sample_indices(sample_size, len(data_1) * len(data_2))
 
@@ -356,7 +383,7 @@ class DisagreementLearner(HasCandidates):
             learner.remove(index)
 
     def mark(self, pairs: TrainingExamples, y: LabelsLike) -> None:
-        self.y = numpy.concatenate([self.y, y])  # type: ignore[arg-type]
+        self.y = numpy.concatenate([self.y, y])
         self.pairs.extend(pairs)
         for learner in self._learners:
             learner.fit(self.pairs, self.y)

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -7,12 +7,12 @@ import logging
 import math
 import random
 from abc import ABC
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from . import blocking
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, Mapping, Sequence, overload
+    from typing import Any, Iterable, Mapping, Sequence
 
     from ._typing import (
         ComparisonCover,

--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -12,9 +12,18 @@ from typing import TYPE_CHECKING
 from . import blocking
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, Mapping, Sequence
+    from typing import Any, Iterable, Mapping, Sequence, overload
 
-    from ._typing import ComparisonCover, Cover, Data, Literal
+    from ._typing import (
+        ComparisonCover,
+        ComparisonCoverInt,
+        ComparisonCoverStr,
+        Cover,
+        Data,
+        DataInt,
+        DataStr,
+        Literal,
+    )
     from ._typing import RecordDictPairs as TrainingExamples
     from ._typing import RecordID, RecordIDPair
     from .predicates import Predicate
@@ -172,8 +181,22 @@ class DedupeBlockLearner(BlockLearner):
 
         self.comparison_cover = self.coveredPairs(self.blocker, sampled_records)
 
+    @overload
     @staticmethod
-    def coveredPairs(blocker: blocking.Fingerprinter, records: Data) -> ComparisonCover:
+    def coveredPairs(
+        blocker: blocking.Fingerprinter, records: DataInt
+    ) -> ComparisonCoverInt:
+        ...
+
+    @overload
+    @staticmethod
+    def coveredPairs(
+        blocker: blocking.Fingerprinter, records: DataStr
+    ) -> ComparisonCoverStr:
+        ...
+
+    @staticmethod
+    def coveredPairs(blocker: blocking.Fingerprinter, records):
         cover = {}
 
         n_records = len(records)
@@ -205,12 +228,32 @@ class DedupeBlockLearner(BlockLearner):
 
 
 class RecordLinkBlockLearner(BlockLearner):
+    @overload
     def __init__(
         self,
         predicates: Iterable[Predicate],
-        sampled_records_1: Data,
-        sampled_records_2: Data,
-        data_2: Data,
+        sampled_records_1: DataInt,
+        sampled_records_2: DataInt,
+        data_2: DataInt,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self,
+        predicates: Iterable[Predicate],
+        sampled_records_1: DataStr,
+        sampled_records_2: DataStr,
+        data_2: DataStr,
+    ):
+        ...
+
+    def __init__(
+        self,
+        predicates,
+        sampled_records_1,
+        sampled_records_2,
+        data_2,
     ):
 
         self.blocker = blocking.Fingerprinter(predicates)
@@ -220,9 +263,19 @@ class RecordLinkBlockLearner(BlockLearner):
             self.blocker, sampled_records_1, sampled_records_2
         )
 
+    @overload
     def coveredPairs(
-        self, blocker: blocking.Fingerprinter, records_1: Data, records_2: Data
-    ) -> ComparisonCover:
+        self, blocker: blocking.Fingerprinter, records_1: DataInt, records_2: DataInt
+    ) -> ComparisonCoverInt:
+        ...
+
+    @overload
+    def coveredPairs(
+        self, blocker: blocking.Fingerprinter, records_1: DataStr, records_2: DataStr
+    ) -> ComparisonCoverStr:
+        ...
+
+    def coveredPairs(self, blocker, records_1, records_2):
         cover: dict[Predicate, dict[str, tuple[set[RecordID], set[RecordID]]]] = {}
         pair_cover = {}
         n_records_1 = len(records_1)
@@ -369,10 +422,10 @@ class BranchBound(object):
 
 
 class InfiniteSet(object):
-    def __and__(self, item):  # type: ignore[no-untyped-def]
+    def __and__(self, item):
         return item
 
-    def __rand__(self, item):  # type: ignore[no-untyped-def]
+    def __rand__(self, item):
         return item
 
 


### PR DESCRIPTION
When I was using dedupe in another project, i noticed that we had, in many places, said we expected record ids to be a mixture of integers or strings. In reality, we need the record ids to either be purely integers or purely strings. This fixes that typing.

It's not quite done, because it is possible for the two datasets in RecordLinkage and Gazetteer code to have different id types, and i haven't handled that possibility yet.

closes #1136 