### PR TITLE
fix: loading training pairs from an existing training.json file

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -1164,8 +1164,7 @@ class ActiveMatching(Matching):
         """
 
         logger.info("reading training from file")
-        training_pairs = serializer.read_training(training_file)
-        self.mark_pairs(training_pairs)
+        self.training_pairs = serializer.read_training(training_file)
 
     def train(
         self, recall: float = 1.00, index_predicates: bool = True


### PR DESCRIPTION
Patch submitted in order to read training data from an existing training.json file.

context: https://github.com/dedupeio/csvdedupe/issues/99