### PR TITLE
Add support for record id of bytes type

### DIFF
--- a/dedupe/core.py
+++ b/dedupe/core.py
@@ -325,6 +325,8 @@ def sniff_id_type(ids: Sequence[tuple[RecordID, RecordID]]) -> RecordIDDType:
     elif python_type is int:
         int(example)  # make sure we can cast to int
         dtype = int
+    elif python_type is bytes:
+        dtype = (bytes, 256)  # type: ignore[assignment]
     else:
         raise ValueError("Invalid type for record id")
 


### PR DESCRIPTION
Add support for id columns of type `bytes`.

Reason: when the primary key of a row is the output of a hashing function, the most natural data type used for the corresponding database column is simply raw bytes (e.g., the BYTEA data type in postgreSQL).

I have already successfully used this patched version of dedupe to deduplicate rows from a postgresSQL table having the primary column of type BYTEA.

Let me know if:
  1. you are interested in adding support for id columns with `bytes` type
  2. you prefer to keep this change under the hood (as it is now) or make it explicit and update all the typing definitions in `_typing.py`
