### PR TITLE
Add __len__ method to ExistType

### DIFF
--- a/dedupe/variables/exists.py
+++ b/dedupe/variables/exists.py
@@ -29,7 +29,7 @@ class ExistsType(FieldType):
             return self.cat_comparator(0, 1)
         else:
             return self.cat_comparator(0, 0)
-        
+
     def __len__(self) -> int:
         return len(self.higher_vars)
 

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -11,3 +11,10 @@ class TestExists(unittest.TestCase):
         assert numpy.array_equal(var.comparator(None, None), [0, 0])
         assert numpy.array_equal(var.comparator(1, 1), [1, 0])
         assert numpy.array_equal(var.comparator(1, 0), [0, 1])
+
+    def test_len_higher_vars(self):
+        # The len > 1 is neccessary for the correct processing in datamodel.py
+        var = ExistType("foo")
+        assert len(var) > 1
+        assert len(var.higher_vars) > 1
+        assert len(var) == len(var.higher_vars)

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -14,7 +14,7 @@ class TestExists(unittest.TestCase):
 
     def test_len_higher_vars(self):
         # The len > 1 is neccessary for the correct processing in datamodel.py
-        var = ExistType("foo")
+        var = ExistsType("foo")
         assert len(var) > 1
         assert len(var.higher_vars) > 1
         assert len(var) == len(var.higher_vars)


### PR DESCRIPTION
Adds __len__ method to the `ExistType` like in `CategoricalType`. Otherwise the  ExistType will use the `__len__` method of `Variable`:
```
    def __len__(self) -> int:
        return 1
```

and higher_vars won't be expanded correctly in `datamodel.py`:

```
        for variable in self.field_variables:
            if len(variable) == 1:
                columns.append(variable)
            elif len(variable) > 1:
                assert hasattr(variable, "higher_vars")
                columns.extend(variable.higher_vars)
```