### PR TITLE
Fixed Spelling Mistakes

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -89,7 +89,7 @@ class Matching:
     def fingerprinter(self) -> blocking.Fingerprinter:
         if self._fingerprinter is None:
             raise ValueError(
-                "the record fingerprinter is not intialized, "
+                "the record fingerprinter is not initialized, "
                 "please run the train method"
             )
 

--- a/dedupe/clustering.py
+++ b/dedupe/clustering.py
@@ -201,7 +201,7 @@ def condensedDistance(
 
     N = len(candidate_set)
 
-    # alternate form thanks to wolfram alpa
+    # alternate form thanks to Wolfram Alpha
     index = row * (2 * N - row - 3) // 2 + col - 1
 
     condensed_distances = numpy.ones(N * (N - 1) // 2, "f4")

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -66,7 +66,7 @@ class TestLatLongGrid(unittest.TestCase):
         assert block_val == set()
 
 
-class TestAlpaNumeric(unittest.TestCase):
+class TestAlphaNumeric(unittest.TestCase):
     def test_alphanumeric(self):
         assert predicates.alphaNumericPredicate("a1") == {"a1"}
         assert predicates.alphaNumericPredicate("1a") == {"1a"}


### PR DESCRIPTION
### Summary

- fix a typo in an error message
- correct a comment referencing Wolfram Alpha
- rename a test class to TestAlphaNumeric

### Testing
`pre-commit run --files dedupe/api.py dedupe/clustering.py tests/test_predicates.py`
`pytest -q`

[https://chatgpt.com/codex/tasks/task_e_684c62b8ef5c8330b3e2cac487217c33](https://chatgpt.com/codex/tasks/task_e_684c62b8ef5c8330b3e2cac487217c33)