### PR TITLE
Add `scipy-stubs` as dev dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pytest-cov
 virtualenv
 isort
 pre-commit
+scipy-stubs; python_version>='3.10'


### PR DESCRIPTION
I noticed that `scipy` is used in `dedupe/clustering.py` and the tests. To help improve type-checking (i.e. mypy) and IDE support, [scipy-stubs](https://github.com/scipy/scipy-stubs) can help (a lot). It doesn't require `scipy` (it's an optional dep), so the runtime impact this has on CI will be minimal :)