### PR TITLE
Disable deprecated numpy mypy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ packages = ["dedupe", "dedupe.variables"]
 dedupe = ["py.typed"]
 
 [tool.mypy]
-plugins = "numpy.typing.mypy_plugin"
 files = ["dedupe"]
 show_error_codes = true
 ignore_missing_imports = true


### PR DESCRIPTION
The NumPy mypy plugin was deprecated in numpy 2.3, and we're planning on removing it in 2.6.0. While working on this, mypy_primer  showed (see https://github.com/numpy/numpy/pull/31931#issuecomment-4923936672) that `dedupe` was still using this mypy plugin. So here I am :)